### PR TITLE
Add support for value of object type

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,9 @@ may have the following properties:
 * `fields`: An object containing the fields that all input messages
   should have. This is vital since filters typically are configured
   based on the event's type and/or tags. Scalar values (strings,
-  numbers, and booleans) are supported, as are arrays of scalars. It
-  seems Logstash doesn't support nested arrays.
+  numbers, and booleans) are supported, as are objects (containing
+  scalars, arrays and nested objects), arrays of scalars and nested arrays.
+  The only combination which is not allowed are objects within arrays.
 * `ignore`: An array with the names of the fields that should be
   removed from the events that Logstash emit. This is for example
   useful for dynamically generated fields whose contents can't be


### PR DESCRIPTION
Nested fields (values of object type) are addressed in Logstash with
field reference notation ([1]). The nested field names are put into square
brackets [], starting on the top level. If a top level field is addressed,
the square brackets might be omited.

Currently values of object type are not allowed in arrays.

Fixes #12

[1]: https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#logstash-config-field-references