### PR TITLE
Parallel execution of multiple test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: go
 go:
-  - 1.6.3
+  - go1.8
 script:
   - make test

--- a/README.md
+++ b/README.md
@@ -232,6 +232,19 @@ for f in `ls -1 *.json`; do jq '{ codec, fields, ignore, testcases:[[.input[]], 
 This command only works for test case files, where for every line in
 `input` an element in `expected` exists.
 
+## Notes about the flag --sockets
+
+The command line flag `--sockets` allows to use unix domain sockets instead of
+stdin to send the input to Logstash. The advantage of this approach is, that
+it allows to process test case files in parallel to Logstash, instead of
+starting a new Logstash instance for every test case file. Because Logstash
+is known to start slowly, this increases the time needed significantly,
+especially if there are lots of different test case files.
+
+For the test cases to work properly together with the unix domain socket input,
+the test case files need to include the property `codec` set to the value `lines`
+(or `json_lines`, if json formatted input should be processed).
+
 ## Known limitations and future work
 
 * Some log formats don't include all timestamp components. For

--- a/logstash-filter-verifier.go
+++ b/logstash-filter-verifier.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+
+	"time"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/magnusbaeck/logstash-filter-verifier/logging"
@@ -37,6 +40,10 @@ var (
 			Flag("logstash-path", "Set the path to the Logstash executable.").
 			Default("/opt/logstash/bin/logstash").
 			String()
+	unixSockets = kingpin.
+			Flag("sockets", "Use Unix domain sockets for the communication with Logstash.").
+			Default("false").
+			Bool()
 
 	// Arguments
 	testcasePath = kingpin.
@@ -102,6 +109,75 @@ func runTests(logstashPath string, tests []testcase.TestCase, configPaths []stri
 	return nil
 }
 
+const unixSocketCommTimeout = 60 * time.Second
+
+// runParallelTests runs multiple set of configuration in a single
+// instance of Logstash against a slice of test cases and compares
+// the actual events against the expected set. Returns an error if
+// at least one test case fails or if there's a problem running the tests.
+func runParallelTests(logstashPath string, tests []testcase.TestCase, configPaths []string, diffCommand []string, keptEnvVars []string) error {
+	var testStreams []*logstash.TestStream
+
+	for _, t := range tests {
+		ts, err := logstash.NewTestStream(t.Codec, t.InputFields, unixSocketCommTimeout)
+		if err != nil {
+			logstash.CleanupTestStreams(testStreams)
+			return err
+		}
+		testStreams = append(testStreams, ts)
+	}
+
+	p, err := logstash.NewParallelProcess(logstashPath, testStreams, keptEnvVars, configPaths...)
+	if err != nil {
+		return err
+	}
+	defer p.Release()
+	if err = p.Start(); err != nil {
+		return err
+	}
+
+	for i, t := range tests {
+		for _, line := range t.InputLines {
+			_, err = testStreams[i].Write([]byte(line + "\n"))
+			if err != nil {
+				return err
+			}
+		}
+
+		if err = testStreams[i].Close(); err != nil {
+			return err
+		}
+	}
+
+	result, err := p.Wait()
+	if err != nil {
+		message := fmt.Sprintf("Error running Logstash: %s.", err)
+		if result.Output != "" {
+			message += fmt.Sprintf("\nProcess output:\n%s", result.Output)
+		} else {
+			message += "\nThe process wrote nothing to stdout or stderr."
+		}
+		if result.Log != "" {
+			message += fmt.Sprintf("\nLog:\n%s", result.Log)
+		} else {
+			message += "\nThe process wrote nothing to its logfile."
+		}
+		return errors.New(message)
+	}
+	ok := true
+	for i, t := range tests {
+		if err = t.Compare(result.Events[i], false, diffCommand); err != nil {
+			userError("Testcase failed, continuing with the rest: %s", err.Error())
+			ok = false
+		}
+	}
+
+	if !ok {
+		return errors.New("One or more testcases failed.")
+	}
+	return nil
+}
+
 // prefixedUserError prints an error message to stderr and prefixes it
 // with the name of the program file (e.g. "logstash-filter-verifier:
 // something bad happened.").
@@ -146,9 +222,21 @@ func main() {
 		userError(err.Error())
 		os.Exit(1)
 	}
-	if err = runTests(*logstashPath, tests, *configPaths, diffCmd, *keptEnvVars); err != nil {
-		userError(err.Error())
-		os.Exit(1)
+	if *unixSockets {
+		if runtime.GOOS == "windows" {
+			userError("Use of Unix domain sockets for communication with Logstash is not supported on Windows.")
+			os.Exit(1)
+		}
+		fmt.Println("Use Unix domain sockets.")
+		if err = runParallelTests(*logstashPath, tests, *configPaths, diffCmd, *keptEnvVars); err != nil {
+			userError(err.Error())
+			os.Exit(1)
+		}
+	} else {
+		if err = runTests(*logstashPath, tests, *configPaths, diffCmd, *keptEnvVars); err != nil {
+			userError(err.Error())
+			os.Exit(1)
+		}
 	}
 	os.Exit(0)
 }

--- a/logstash/main_test.go
+++ b/logstash/main_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2016 Magnus Bäck <magnus@noun.se>
+
+package logstash
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+)
+
+// If a TestMain function is present, this is executed instead of running all the tests,
+// if `go test` is executed. This allows us to use the test binary as a logstashMock
+// in TestParallelProcess. The logstashMock is executed, if the env var
+// `TEST_MAIN=logstash-mock` is set.
+func TestMain(m *testing.M) {
+	switch os.Getenv("TEST_MAIN") {
+	case "logstash-mock":
+		logstashMock()
+	default:
+		os.Exit(m.Run())
+	}
+}
+
+// lostashMock returns all input (unprocessed), received on the unix domain socket provided in
+// the env var `TEST_SOCKET` via stdout.
+func logstashMock() {
+	conn, err := net.Dial("unix", os.Getenv("TEST_SOCKET"))
+	if err != nil {
+		log.Fatalf("Failed to dial %s with error: %s", os.Getenv("TEST_SOCKET"), err)
+	}
+	b, err := ioutil.ReadAll(conn)
+	if err != nil {
+		log.Fatalf("Eror while reading from socket: %s", err)
+	}
+	fmt.Print(string(b))
+}

--- a/logstash/parallel_process.go
+++ b/logstash/parallel_process.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2015-2016 Magnus Bäck <magnus@noun.se>
+
+package logstash
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TestStream contains the input and output streams for one test case
+type TestStream struct {
+	sender         *net.UnixConn
+	senderListener *net.UnixListener
+	senderReady    chan struct{}
+	senderPath     string
+	receiver       *deletedTempFile
+	timeout        time.Duration
+
+	inputCodec string
+	fields     FieldSet
+}
+
+// NewTestStream creates a TestStream, inputCodec is
+// the desired codec for the stdin input and inputType the value of
+// the "type" field for ingested events.
+// The timeout defines, how long to wait in Write for the receiver to
+// become available.
+func NewTestStream(inputCodec string, fields FieldSet, timeout time.Duration) (*TestStream, error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	ts := &TestStream{
+		senderReady: make(chan struct{}),
+		senderPath:  dir,
+		inputCodec:  inputCodec,
+		fields:      fields,
+		timeout:     timeout,
+	}
+
+	ts.senderListener, err = net.ListenUnix("unix", &net.UnixAddr{Name: ts.senderPath + "/socket", Net: "unix"})
+	if err != nil {
+		log.Fatalf("Unable to create unix socket for listening: %s", err)
+	}
+	ts.senderListener.SetUnlinkOnClose(false)
+
+	go func() {
+		defer close(ts.senderReady)
+
+		ts.sender, err = ts.senderListener.AcceptUnix()
+		if err != nil {
+			log.Errorf("Error while accept unix socket: %s", err)
+		}
+		ts.senderListener.Close()
+	}()
+
+	// Unfortunately Logstash doesn't make it easy to just read
+	// events from a stdout-connected pipe and the log from a
+	// stderr-connected pipe. Stdout can contain other garbage (at
+	// the very least "future logs will be sent to ...") and error
+	// messages could very well be sent there too. Mitigate by
+	// having Logstash write output logs to a temporary file and
+	// its own logs to a different temporary file.
+	outputFile, err := newDeletedTempFile("", "")
+	if err != nil {
+		return nil, err
+	}
+	ts.receiver = outputFile
+
+	return ts, nil
+}
+
+// Write writes to the sender of the TestStream
+func (ts *TestStream) Write(p []byte) (n int, err error) {
+	timer := time.NewTimer(ts.timeout)
+	select {
+	case <-ts.senderReady:
+	case <-timer.C:
+		return 0, fmt.Errorf("Write timeout error")
+	}
+	return ts.sender.Write(p)
+}
+
+// Close closes the sender of the TestStream
+func (ts *TestStream) Close() error {
+	if ts.sender != nil {
+		err := ts.sender.Close()
+		ts.sender = nil
+		return err
+	}
+	return nil
+}
+
+// Cleanup closes and removes all temporary resources
+// for a TestStream
+func (ts *TestStream) Cleanup() {
+	if ts.senderListener != nil {
+		ts.senderListener.Close()
+	}
+	if ts.sender != nil {
+		ts.Close()
+	}
+	os.RemoveAll(ts.senderPath)
+	if ts.receiver != nil {
+		ts.receiver.Close()
+	}
+}
+
+// CleanupTestStreams closes all sockets and streams as well
+// removes temporary file ressources for an array of
+// TestStreams
+func CleanupTestStreams(ts []*TestStream) {
+	for i := range ts {
+		ts[i].Cleanup()
+	}
+}
+
+// ParallelProcess represents the invocation and execution of a Logstash child
+// process that emits JSON events from multiple inputs through filter to multiple outputs
+// configuration files supplied by the caller.
+type ParallelProcess struct {
+	streams []*TestStream
+
+	child     *exec.Cmd
+	configDir *string
+	log       io.ReadCloser
+
+	stdio io.Reader
+}
+
+// NewParallelProcess prepares for the execution of a new Logstash process but
+// doesn't actually start it. logstashPath is the path to the Logstash
+// executable (typically /opt/logstash/bin/logstash). The configs parameter is
+// one or more configuration files containing Logstash filters.
+func NewParallelProcess(logstashPath string, testStream []*TestStream, keptEnvVars []string, configs ...string) (*ParallelProcess, error) {
+	if len(configs) == 0 {
+		return nil, errors.New("must provide non-empty list of configuration file or directory names")
+	}
+
+	logstashInput := make([]string, len(testStream))
+	logstashOutput := make([]string, len(testStream))
+
+	for i, sp := range testStream {
+		sp.fields["@metadata"] = map[string]interface{}{"testcase": strconv.Itoa(i)}
+		fieldHash, err := sp.fields.LogstashHash()
+		if err != nil {
+			CleanupTestStreams(testStream)
+			return nil, err
+		}
+		logstashInput[i] = fmt.Sprintf("unix { mode => \"client\" path => %q codec => %q add_field => %s }", sp.senderPath+"/socket", sp.inputCodec, fieldHash)
+		logstashOutput[i] = fmt.Sprintf("if [@metadata][testcase] == \"%s\" { file { path => %q codec => \"json_lines\" } }", strconv.Itoa(i), sp.receiver.Name())
+	}
+
+	logFile, err := newDeletedTempFile("", "")
+	if err != nil {
+		CleanupTestStreams(testStream)
+		return nil, err
+	}
+
+	configDir, err := getConfigFileDir(configs)
+	if err != nil {
+		CleanupTestStreams(testStream)
+		_ = logFile.Close()
+		return nil, err
+	}
+
+	args := []string{
+		"-w", // Make messages arrive in order.
+		"1",
+		"--debug",
+		"-e",
+		fmt.Sprintf(
+			"input { %s } "+
+				"output { %s }",
+			strings.Join(logstashInput, " "), strings.Join(logstashOutput, " ")),
+		"--config",
+		configDir,
+		"--log",
+		logFile.Name(),
+	}
+
+	p, err := newParallelProcessWithArgs(logstashPath, args, getLimitedEnvironment(os.Environ(), keptEnvVars))
+	if err != nil {
+		CleanupTestStreams(testStream)
+		_ = logFile.Close()
+	}
+	p.configDir = &configDir
+	p.log = logFile
+	p.streams = testStream
+	return p, nil
+}
+
+// newParallelProcessWithArgs performs the non-Logstash specific low-level
+// actions of preparing to spawn a child process, making it easier to
+// test the code in this package.
+func newParallelProcessWithArgs(command string, args []string, env []string) (*ParallelProcess, error) {
+	c := exec.Command(command, args...)
+	c.Env = env
+
+	// Save the process's stdout and stderr since an early startup
+	// failure (e.g. JVM issues) will get dumped there and not in
+	// the log file.
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+
+	return &ParallelProcess{
+		child: c,
+		stdio: &b,
+	}, nil
+}
+
+// Start starts a Logstash child process with the previously supplied
+// configuration.
+func (p *ParallelProcess) Start() error {
+	log.Info("Starting %q with args %q.", p.child.Path, p.child.Args[1:])
+	return p.child.Start()
+}
+
+// Wait blocks until the started Logstash process terminates and
+// returns the result of the execution.
+func (p *ParallelProcess) Wait() (*ParallelResult, error) {
+	if p.child.Process == nil {
+		return nil, errors.New("can't wait on an unborn process")
+	}
+	log.Debug("Waiting for child with pid %d to terminate.", p.child.Process.Pid)
+
+	waiterr := p.child.Wait()
+
+	// Save the log output regardless of whether the child process
+	// succeeded or not.
+	logbuf, logerr := ioutil.ReadAll(p.log)
+	if logerr != nil {
+		// Log this weird error condition but don't let it
+		// fail the function. We don't care about the log
+		// contents unless Logstash fails, in which we'll
+		// report that problem anyway.
+		log.Error("Error reading the Logstash logfile: %s", logerr.Error())
+	}
+	outbuf, _ := ioutil.ReadAll(p.stdio)
+
+	result := ParallelResult{
+		Events:  [][]Event{},
+		Log:     string(logbuf),
+		Output:  string(outbuf),
+		Success: waiterr == nil,
+	}
+	if waiterr != nil {
+		if strings.Contains(result.Log, `:message=>"An unexpected error occurred!", :error=>"closed stream", :class=>"IOError"`) {
+			log.Warning("Workaround for IOError in unix.rb on stop, process result anyway. (see https://github.com/logstash-plugins/logstash-input-unix/pull/18)")
+			result.Success = true
+		} else {
+			return &result, waiterr
+		}
+	}
+
+	var err error
+	result.Events = make([][]Event, len(p.streams))
+	for i, tc := range p.streams {
+		result.Events[i], err = readEvents(tc.receiver)
+		tc.receiver.Close()
+		result.Success = err == nil
+	}
+	return &result, err
+}
+
+// Release frees all allocated resources connected to this process.
+func (p *ParallelProcess) Release() {
+	CleanupTestStreams(p.streams)
+	_ = p.log.Close()
+	if p.configDir != nil {
+		_ = os.RemoveAll(*p.configDir)
+	}
+}

--- a/logstash/parallel_process_test.go
+++ b/logstash/parallel_process_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016 Magnus Bäck <magnus@noun.se>
+
+package logstash
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParallelProcess(t *testing.T) {
+	const testLine = "test line\n"
+
+	fs := FieldSet{}
+	ts, err := NewTestStream("Codec", fs, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Unable to create TestStream: %s", err)
+	}
+	defer CleanupTestStreams([]*TestStream{ts})
+
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temporary config file: %s", err)
+	}
+	configPaths := []string{file.Name()}
+
+	p, err := NewParallelProcess(os.Args[0], []*TestStream{ts}, []string{}, configPaths...)
+	if err != nil {
+		t.Fatalf("Unable to create ParallelProcess: %s", err)
+	}
+	defer p.Release()
+
+	p.child.Env = append(os.Environ(), "TEST_MAIN=logstash-mock", "TEST_SOCKET="+ts.senderPath+"/socket")
+
+	if err = p.Start(); err != nil {
+		t.Fatalf("Unable to start ParallelProcess: %s", err)
+	}
+
+	_, err = ts.Write([]byte(testLine))
+	if err != nil {
+		t.Fatalf("Unable to wirte to TestStream: %s", err)
+	}
+	if err = ts.Close(); err != nil {
+		t.Fatalf("Unable to close TestStream: %s", err)
+	}
+
+	result, err := p.Wait()
+	if err != nil {
+		t.Fatalf("Error while Wait for ParallelProcess to finish: %s", err)
+	}
+	if result.Output != testLine {
+		t.Errorf("Unexpected return from ParallelProcess, expected: %s, got: %s", testLine, result.Output)
+	}
+}

--- a/logstash/result.go
+++ b/logstash/result.go
@@ -22,5 +22,26 @@ type Result struct {
 	Output string
 }
 
+// ParallelResult contains the results of a parallel Logstash execution,
+// where multiple test cases are run in parallel via unix domain sockets.
+type ParallelResult struct {
+	// Success indicates whether the execution was successful,
+	// i.e. whether the Logstash process terminated with a zero
+	// exit status.
+	Success bool
+
+	// Events contains a slice of the events emitted from
+	// Logstash.
+	Events [][]Event
+
+	// Log contains the contents of the Logstash log file.
+	Log string
+
+	// Output contains stdout and stderr output (if any) of
+	// the Logstash process. If the process fails during
+	// initialization clues can probably be found here.
+	Output string
+}
+
 // Event represents a Logstash event, i.e. basically a JSON document.
 type Event map[string]interface{}


### PR DESCRIPTION
Implements the usage of logstash-input-unix as input, which
allows to use a single Logstash instance for the execution
of multiple test case files, which greatly shortens the
duration for the test execution.

To enable this feature, run logstash-filter-verifier with the
command line flage `--sockets`.
This feature does only work on systems, which do support
unix domain sockets.

The logstash-input-unix plugins adds the two fields `host` and
`path`. Therefore these fields should be ignored in the test cases.

This implementation does need at least Go 1.8beta1, as the function
net.SetUnlinkOnClose is used, which is introduced with Go 1.8.

Fixes #14 
May help for #11