### PR TITLE
Handling large floats

### DIFF
--- a/logstash/configfiledir.go
+++ b/logstash/configfiledir.go
@@ -55,7 +55,7 @@ func getConfigFileDir(configs []string) (string, error) {
 		err = copyFile(f, dest)
 		if err != nil {
 			_ = os.RemoveAll(dir)
-			return "", err
+			return "", fmt.Errorf("Config file copy failed: %s", err)
 		}
 	}
 	fileList, err := getFilesInDir(dir)

--- a/logstash/fieldset.go
+++ b/logstash/fieldset.go
@@ -54,7 +54,12 @@ func serializeAsLogstashLiteral(k string, v interface{}) ([]string, []string, er
 	case int:
 		return []string{k}, []string{fmt.Sprintf("%v", v)}, nil
 	case float64:
-		return []string{k}, []string{fmt.Sprintf("%v", v)}, nil
+		// large floats must not be converted to exponential notation, because this is not valid for Logstash
+		// https://github.com/elastic/logstash/blob/master/logstash-core/lib/logstash/config/grammar.treetop#L92
+		if !strings.Contains(fmt.Sprintf("%v", v), "e") {
+			return []string{k}, []string{fmt.Sprintf("%v", v)}, nil
+		}
+		return []string{k}, []string{fmt.Sprintf("%f", v)}, nil
 	case string:
 		return []string{k}, []string{fmt.Sprintf("%q", v)}, nil
 	case []interface{}:

--- a/logstash/fieldset_test.go
+++ b/logstash/fieldset_test.go
@@ -77,6 +77,15 @@ func TestLogstashHash(t *testing.T) {
 			`{ "a" => 123 }`,
 			nil,
 		},
+		// Large floats must not be converted to exponential notation, because this is not valid for Logstash
+		// https://github.com/elastic/logstash/blob/master/logstash-core/lib/logstash/config/grammar.treetop#L92
+		{
+			FieldSet{
+				"a": 1234567890.123,
+			},
+			`{ "a" => 1234567890.123000 }`,
+			nil,
+		},
 		// Single string value is okay
 		{
 			FieldSet{


### PR DESCRIPTION
Large floats must not be converted to exponential notation, because this is not valid for Logstash
https://github.com/elastic/logstash/blob/master/logstash-core/lib/logstash/config/grammar.treetop#L92

Better error message, if copy of config fails.