### PR TITLE
Testcaseset (have a testcase in one hash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ may have the following properties:
   predicted and hardwired into the test case file.
 * `input`: An array with the lines of input (each line being a string)
   that should be fed to the Logstash process.
+* `testcases`: An array of test case hashes, consisting of a field `input`
+  and a field `expected`, which work the same as the above mentioned
+  `input` and `expected`, but allow to have the input and the expected
+  event close together in the test case file, which offers a better
+  overview.
 
 ## Known limitations and future work
 

--- a/logstash-filter-verifier.go
+++ b/logstash-filter-verifier.go
@@ -53,7 +53,7 @@ var (
 // slice of test cases and compares the actual events against the
 // expected set. Returns an error if at least one test case fails or
 // if there's a problem running the tests.
-func runTests(logstashPath string, tests []testcase.TestCase, configPaths []string, diffCommand []string, keptEnvVars []string) error {
+func runTests(logstashPath string, tests []testcase.TestCaseSet, configPaths []string, diffCommand []string, keptEnvVars []string) error {
 	ok := true
 	for _, t := range tests {
 		fmt.Fprintf(os.Stderr, "Running tests in %s...\n", filepath.Base(t.File))

--- a/testcase/discover.go
+++ b/testcase/discover.go
@@ -14,7 +14,7 @@ import (
 // TestCase structs or, if the input path is a directory, reads all
 // .json files in that directorory and returns them as TestCase
 // structs.
-func DiscoverTests(path string) ([]TestCase, error) {
+func DiscoverTests(path string) ([]TestCaseSet, error) {
 	pathinfo, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -26,30 +26,30 @@ func DiscoverTests(path string) ([]TestCase, error) {
 	return discoverTestFile(path)
 }
 
-func discoverTestDirectory(path string) ([]TestCase, error) {
+func discoverTestDirectory(path string) ([]TestCaseSet, error) {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("Error discovering test case files: %s", err)
 	}
-	var result []TestCase
+	var result []TestCaseSet
 	for _, f := range files {
 		if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
 			continue
 		}
 		fullpath := filepath.Join(path, f.Name())
-		tc, err := NewFromFile(fullpath)
+		tcs, err := NewFromFile(fullpath)
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, *tc)
+		result = append(result, *tcs)
 	}
 	return result, nil
 }
 
-func discoverTestFile(path string) ([]TestCase, error) {
-	tc, err := NewFromFile(path)
+func discoverTestFile(path string) ([]TestCaseSet, error) {
+	tcs, err := NewFromFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return []TestCase{*tc}, nil
+	return []TestCaseSet{*tcs}, nil
 }

--- a/testcase/discover_test.go
+++ b/testcase/discover_test.go
@@ -81,8 +81,8 @@ func TestDiscoverTests_Directory(t *testing.T) {
 		}
 
 		filenames := make([]string, len(testcases))
-		for i, tc := range testcases {
-			filenames[i] = filepath.Base(tc.File)
+		for i, tcs := range testcases {
+			filenames[i] = filepath.Base(tcs.File)
 		}
 		sort.Strings(filenames)
 

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -70,14 +70,14 @@ type TestCaseSet struct {
 // into the Logstash process and an expected event which is compared
 // to the actual event produced by the Logstash process.
 type TestCase struct {
-	// InputLine contains the line of input that should be fed
+	// InputLines contains the lines of input that should be fed
 	// to the Logstash process.
-	InputLine string `json:"input"`
+	InputLines []string `json:"input"`
 
-	// ExpectedEvent contains an expected event to be
-	// compared to the actual event produced by the Logstash
+	// ExpectedEvents contains a slice of expected events to be
+	// compared to the actual events produced by the Logstash
 	// process.
-	ExpectedEvent logstash.Event `json:"expected"`
+	ExpectedEvents []logstash.Event `json:"expected"`
 }
 
 // ComparisonError indicates that there was a mismatch when the
@@ -126,8 +126,8 @@ func New(reader io.Reader) (*TestCaseSet, error) {
 	}
 	sort.Strings(tcs.IgnoredFields)
 	for _, tc := range tcs.TestCases {
-		tcs.InputLines = append(tcs.InputLines, tc.InputLine)
-		tcs.ExpectedEvents = append(tcs.ExpectedEvents, tc.ExpectedEvent)
+		tcs.InputLines = append(tcs.InputLines, tc.InputLines...)
+		tcs.ExpectedEvents = append(tcs.ExpectedEvents, tc.ExpectedEvents...)
 	}
 	return &tcs, nil
 }

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -57,6 +57,26 @@ type TestCaseSet struct {
 	// compared to the actual events produced by the Logstash
 	// process.
 	ExpectedEvents []logstash.Event `json:"expected"`
+
+	// TestCases is a slice of test cases, which include at minimum
+	// a pair of an input and an expected event
+	// Optionally other information regarding the test case
+	// may be supplied.
+	TestCases []TestCase `json:"testcases"`
+}
+
+// TestCase is a pair of an input line that should be fed
+// into the Logstash process and an expected event which is compared
+// to the actual event produced by the Logstash process.
+type TestCase struct {
+	// InputLine contains the line of input that should be fed
+	// to the Logstash process.
+	InputLine string `json:"input"`
+
+	// ExpectedEvent contains an expected event to be
+	// compared to the actual event produced by the Logstash
+	// process.
+	ExpectedEvent logstash.Event `json:"expected"`
 }
 
 // ComparisonError indicates that there was a mismatch when the
@@ -104,6 +124,10 @@ func New(reader io.Reader) (*TestCaseSet, error) {
 		tcs.IgnoredFields = append(tcs.IgnoredFields, f)
 	}
 	sort.Strings(tcs.IgnoredFields)
+	for _, tc := range tcs.TestCases {
+		tcs.InputLines = append(tcs.InputLines, tc.InputLine)
+		tcs.ExpectedEvents = append(tcs.ExpectedEvents, tc.ExpectedEvent)
+	}
 	return &tcs, nil
 }
 

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -17,9 +17,9 @@ import (
 	"github.com/magnusbaeck/logstash-filter-verifier/logstash"
 )
 
-// TestCase contains the configuration of a Logstash filter test case.
+// TestCaseSet contains the configuration of a Logstash filter test case.
 // Most of the fields are supplied by the user via a JSON file.
-type TestCase struct {
+type TestCaseSet struct {
 	// File is the absolute path to the file from which this
 	// test case was read.
 	File string `json:"-"`
@@ -86,29 +86,29 @@ var (
 // TestCase. Defaults to a "plain" codec and ignoring the @version
 // field. If the configuration being read lists additional fields to
 // ignore those will be ignored in addition to @version.
-func New(reader io.Reader) (*TestCase, error) {
-	tc := TestCase{
+func New(reader io.Reader) (*TestCaseSet, error) {
+	tcs := TestCaseSet{
 		Codec: "plain",
 	}
 	buf, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
-	if err = json.Unmarshal(buf, &tc); err != nil {
+	if err = json.Unmarshal(buf, &tcs); err != nil {
 		return nil, err
 	}
-	if err = tc.InputFields.IsValid(); err != nil {
+	if err = tcs.InputFields.IsValid(); err != nil {
 		return nil, err
 	}
 	for _, f := range defaultIgnoredFields {
-		tc.IgnoredFields = append(tc.IgnoredFields, f)
+		tcs.IgnoredFields = append(tcs.IgnoredFields, f)
 	}
-	sort.Strings(tc.IgnoredFields)
-	return &tc, nil
+	sort.Strings(tcs.IgnoredFields)
+	return &tcs, nil
 }
 
 // NewFromFile reads a test case configuration from an on-disk file.
-func NewFromFile(path string) (*TestCase, error) {
+func NewFromFile(path string) (*TestCaseSet, error) {
 	abspath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
@@ -123,12 +123,12 @@ func NewFromFile(path string) (*TestCase, error) {
 		_ = f.Close()
 	}()
 
-	tc, err := New(f)
+	tcs, err := New(f)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading/unmarshalling %s: %s", path, err)
 	}
-	tc.File = abspath
-	return tc, nil
+	tcs.File = abspath
+	return tcs, nil
 }
 
 // Compare compares a slice of events against the expected events of
@@ -136,10 +136,10 @@ func NewFromFile(path string) (*TestCase, error) {
 // file and the two files are passed to "diff -u". If quiet is true,
 // the progress messages normally written to stderr will be emitted
 // and the output of the diff program will be discarded.
-func (tc *TestCase) Compare(events []logstash.Event, quiet bool, diffCommand []string) error {
+func (tcs *TestCaseSet) Compare(events []logstash.Event, quiet bool, diffCommand []string) error {
 	result := ComparisonError{
 		ActualCount:   len(events),
-		ExpectedCount: len(tc.ExpectedEvents),
+		ExpectedCount: len(tcs.ExpectedEvents),
 		Mismatches:    []MismatchedEvent{},
 	}
 
@@ -161,10 +161,10 @@ func (tc *TestCase) Compare(events []logstash.Event, quiet bool, diffCommand []s
 
 	for i, actualEvent := range events {
 		if !quiet {
-			fmt.Fprintf(os.Stderr, "Comparing message %d of %s...\n", i+1, filepath.Base(tc.File))
+			fmt.Fprintf(os.Stderr, "Comparing message %d of %s...\n", i+1, filepath.Base(tcs.File))
 		}
 
-		for _, ignored := range tc.IgnoredFields {
+		for _, ignored := range tcs.IgnoredFields {
 			delete(actualEvent, ignored)
 		}
 
@@ -172,13 +172,13 @@ func (tc *TestCase) Compare(events []logstash.Event, quiet bool, diffCommand []s
 		// compared that makes it easy for the user to identify
 		// the failing test case in the diff output:
 		// $TMP/<random>/<test case file>/<event #>/<actual|expected>
-		resultDir := filepath.Join(tempdir, filepath.Base(tc.File), strconv.Itoa(i+1))
+		resultDir := filepath.Join(tempdir, filepath.Base(tcs.File), strconv.Itoa(i+1))
 		actualFilePath := filepath.Join(resultDir, "actual")
 		if err = marshalToFile(actualEvent, actualFilePath); err != nil {
 			return err
 		}
 		expectedFilePath := filepath.Join(resultDir, "expected")
-		if err = marshalToFile(tc.ExpectedEvents[i], expectedFilePath); err != nil {
+		if err = marshalToFile(tcs.ExpectedEvents[i], expectedFilePath); err != nil {
 			return err
 		}
 
@@ -187,7 +187,7 @@ func (tc *TestCase) Compare(events []logstash.Event, quiet bool, diffCommand []s
 			return err
 		}
 		if !equal {
-			result.Mismatches = append(result.Mismatches, MismatchedEvent{actualEvent, tc.ExpectedEvents[i], i})
+			result.Mismatches = append(result.Mismatches, MismatchedEvent{actualEvent, tcs.ExpectedEvents[i], i})
 		}
 	}
 	if len(result.Mismatches) == 0 {

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -56,8 +56,8 @@ func TestNew(t *testing.T) {
 			t.Errorf("Test %d: %q input: %s", i, c.input, err)
 			break
 		}
-		resultJSON := marshalTestCase(t, tcs)
-		expectedJSON := marshalTestCase(t, &c.expected)
+		resultJSON := marshalTestCaseSet(t, tcs)
+		expectedJSON := marshalTestCaseSet(t, &c.expected)
 		if expectedJSON != resultJSON {
 			t.Errorf("Test %d:\nExpected:\n%s\nGot:\n%s", i, expectedJSON, resultJSON)
 		}
@@ -368,7 +368,7 @@ func TestMarshalToFile(t *testing.T) {
 	}
 }
 
-func marshalTestCase(t *testing.T, tcs *TestCaseSet) string {
+func marshalTestCaseSet(t *testing.T, tcs *TestCaseSet) string {
 	resultBuf, err := json.MarshalIndent(tcs, "", "  ")
 	if err != nil {
 		t.Errorf("Failed to marshal %+v as JSON: %s", tcs, err)


### PR DESCRIPTION
**Added testcases section to the test case file**
    
The test case file now supports an additional section called `testcases`, which consists of an input line and the expected event, after processed by Logstash.

This allows for clean test case files, as the actual input is just next to the expected output, which makes working with the test case files much easier.

**Renamed TestCase to TestCaseSet**

Renamed TestCase to TestCaseSet in preparation for the additon of the extended testcase feature in the config files. (separate commit).

**Future improvements**

The new `testcases` struct could be further extended, for example with the following fields:

* `json_lines`: as an alternative way to provide the input, which would remove the need for the escaping of json input in the `input` field.
* `ignore_fields`: fields, that should be ignored just for the actual test case, additionally to the globally defined ignored fields.
* `description`: short description field for the test case, which would allow to describe, why the test case was added, e.g. with reference to ticket describing the bug/issue. This description could be printed while running the tests instead of (or additional to) the current outout: `Comparing message <n> of <filename>...`