### PR TITLE
Changed default codec from `plain` to `line`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ ambiguous grok expressions. Here's an example:
 ```
 
 When you feed events like this to Logstash it's likely that the
-input used will have its codec set to "json". This is something we
+input used will have its codec set to "json_lines". This is something we
 should mimic on the Logstash Filter Verifier side too. Use `codec` for
 that:
 
@@ -161,7 +161,7 @@ that:
   "fields": {
     "type": "app"
   }
-  "codec": "json",
+  "codec": "json_lines",
   "ignore": ["host"],
   "input": [
     "{\"message\": \"This is a test message\", \"client\": \"127.0.0.1\", \"time\": \"2015-10-06T20:55:29Z\"}"
@@ -199,7 +199,7 @@ Test case files are JSON files containing a single object. That object
 may have the following properties:
 
 * `codec`: A string value naming the Logstash codec that should be
-  used when events are read. This is normally "plain" or "json".
+  used when events are read. This is normally "line" or "json_lines".
 * `expected`: An array of JSON objects with the events to be
   expected. They will be compared to the actual events produced by the
   Logstash process.

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -26,7 +26,7 @@ type TestCaseSet struct {
 	File string `json:"-"`
 
 	// Codec names the Logstash codec that should be used when
-	// events are read. This is normally "plain" or "json".
+	// events are read. This is normally "line" or "json_lines".
 	Codec string `json:"codec"`
 
 	// IgnoredFields contains a list of fields that will be
@@ -104,12 +104,12 @@ var (
 )
 
 // New reads a test case configuration from a reader and returns a
-// TestCase. Defaults to a "plain" codec and ignoring the @version
+// TestCase. Defaults to a "line" codec and ignoring the @version
 // field. If the configuration being read lists additional fields to
 // ignore those will be ignored in addition to @version.
 func New(reader io.Reader) (*TestCaseSet, error) {
 	tcs := TestCaseSet{
-		Codec: "plain",
+		Codec: "line",
 	}
 	buf, err := ioutil.ReadAll(reader)
 	if err != nil {

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 		{
 			`{"fields": {"type": "mytype"}}`,
 			TestCaseSet{
-				Codec: "plain",
+				Codec: "line",
 				InputFields: logstash.FieldSet{
 					"type": "mytype",
 				},
@@ -32,9 +32,9 @@ func TestNew(t *testing.T) {
 		},
 		// Happy flow with a custom codec.
 		{
-			`{"fields": {"type": "mytype"}, "codec": "json"}`,
+			`{"fields": {"type": "mytype"}, "codec": "json_lines"}`,
 			TestCaseSet{
-				Codec: "json",
+				Codec: "json_lines",
 				InputFields: logstash.FieldSet{
 					"type": "mytype",
 				},
@@ -45,7 +45,7 @@ func TestNew(t *testing.T) {
 		{
 			`{"ignore": ["foo"]}`,
 			TestCaseSet{
-				Codec:         "plain",
+				Codec:         "line",
 				IgnoredFields: []string{"@version", "foo"},
 			},
 		},
@@ -118,7 +118,7 @@ func TestCompare(t *testing.T) {
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
-				Codec:          "plain",
+				Codec:          "line",
 				InputLines:     []string{},
 				ExpectedEvents: []logstash.Event{},
 			},
@@ -133,7 +133,7 @@ func TestCompare(t *testing.T) {
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
-				Codec:      "plain",
+				Codec:      "line",
 				InputLines: []string{},
 				ExpectedEvents: []logstash.Event{
 					{
@@ -163,7 +163,7 @@ func TestCompare(t *testing.T) {
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
-				Codec:      "plain",
+				Codec:      "line",
 				InputLines: []string{},
 				ExpectedEvents: []logstash.Event{
 					{
@@ -193,7 +193,7 @@ func TestCompare(t *testing.T) {
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
-				Codec:      "plain",
+				Codec:      "line",
 				InputLines: []string{},
 				ExpectedEvents: []logstash.Event{
 					{
@@ -230,7 +230,7 @@ func TestCompare(t *testing.T) {
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
-				Codec:      "plain",
+				Codec:      "line",
 				InputLines: []string{},
 				ExpectedEvents: []logstash.Event{
 					{
@@ -267,7 +267,7 @@ func TestCompare(t *testing.T) {
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
-				Codec:         "plain",
+				Codec:         "line",
 				IgnoredFields: []string{"ignored"},
 				InputLines:    []string{},
 				ExpectedEvents: []logstash.Event{
@@ -292,7 +292,7 @@ func TestCompare(t *testing.T) {
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
-				Codec:      "plain",
+				Codec:      "line",
 				InputLines: []string{},
 				ExpectedEvents: []logstash.Event{
 					{


### PR DESCRIPTION
recommend `json_lines` instead of `json`
to support the unix domain socket mode, without the
need to modify the test cases.

Fixes #24