### PR TITLE
Remove the input and output config sections

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -2,6 +2,7 @@ github.com/alecthomas/gometalinter                    v2.0.2
 github.com/alecthomas/kingpin                         v2.2.2
 github.com/axw/gocov/gocov                            ac431cdb392e
 github.com/blang/semver                               v3.5.0
+github.com/breml/logstash-config                      b63fee1652eb
 github.com/go-playground/overalls                     845469c90499
 github.com/mattn/go-shellwords                        f4e566c536cf
 github.com/mitchellh/packer                           v0.9.0

--- a/logstash/invocation_test.go
+++ b/logstash/invocation_test.go
@@ -196,7 +196,7 @@ func createTestInvocation(version semver.Version) (*testInvocation, error) {
 	}
 
 	configFile := filepath.Join(tempdir, "configfile.conf")
-	configContents := "dummy configuration file"
+	configContents := ""
 	if err = ioutil.WriteFile(configFile, []byte(configContents), 0644); err != nil {
 		return nil, fmt.Errorf("Unexpected error when creating dummy configuration file: %s", err)
 	}

--- a/logstash/pipelineconfigdir.go
+++ b/logstash/pipelineconfigdir.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	lsparser "github.com/breml/logstash-config"
+	"github.com/breml/logstash-config/ast"
 )
 
 // getPipelineConfigDir copies one or more Logstash pipeline
@@ -34,6 +37,12 @@ func getPipelineConfigDir(dir string, configs []string) error {
 		if err != nil {
 			_ = os.RemoveAll(dir)
 			return fmt.Errorf("Config file copy failed: %s", err)
+		}
+
+		err = removeInputOutput(dest)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return fmt.Errorf("Failed to remove the input and output sections: %s", err)
 		}
 	}
 	fileList, err := getFilesInDir(dir)
@@ -89,4 +98,24 @@ func getTempFileWithSuffix(dir string, suffix string) (string, error) {
 		return filename, nil
 	}
 	return "", fmt.Errorf("unable to generate a temporary filename despite %d attempts", maxAttempts)
+}
+
+// removeInputOutput removes the input and output sections in the
+// given logtsash configuration file. The operation is done in place
+// and the original file content is replaced.
+func removeInputOutput(path string) error {
+	parsed, err := lsparser.ParseFile(path)
+	if err != nil {
+		return err
+	}
+
+	if parsed == nil {
+		return fmt.Errorf("count not parse the following logstash config file: %v", path)
+	}
+
+	config := parsed.(ast.Config)
+	config.Input = nil
+	config.Output = nil
+
+	return ioutil.WriteFile(path, []byte(config.String()), 0644)
 }

--- a/logstash/pipelineconfigdir.go
+++ b/logstash/pipelineconfigdir.go
@@ -101,7 +101,7 @@ func getTempFileWithSuffix(dir string, suffix string) (string, error) {
 }
 
 // removeInputOutput removes the input and output sections in the
-// given logtsash configuration file. The operation is done in place
+// given logstash configuration file. The operation is done in place
 // and the original file content is replaced.
 func removeInputOutput(path string) error {
 	parsed, err := lsparser.ParseFile(path)
@@ -110,7 +110,7 @@ func removeInputOutput(path string) error {
 	}
 
 	if parsed == nil {
-		return fmt.Errorf("count not parse the following logstash config file: %v", path)
+		return fmt.Errorf("could not parse the following logstash config file: %v", path)
 	}
 
 	config := parsed.(ast.Config)

--- a/logstash/pipelineconfigdir_test.go
+++ b/logstash/pipelineconfigdir_test.go
@@ -170,3 +170,52 @@ func TestGetFilesInDir(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveInputOutputBasicConfig(t *testing.T) {
+	f, err := ioutil.TempFile("", "lsconf")
+	if err != nil {
+		t.Error(err)
+	}
+
+	path := f.Name()
+	defer os.Remove(path)
+
+	err = ioutil.WriteFile(path, []byte("input { beats { port => 5044 } } filter { grok {} } output{ elasticsearch {} }"), 0644)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = removeInputOutput(path)
+	if err != nil {
+		t.Error(err)
+	}
+
+	data, err := ioutil.ReadFile(path)
+    if err != nil {
+        t.Error(err)
+    }
+
+	t.Logf("CONFIG IS: %s", data)
+}
+
+func TestRemoveInputOutputEmptyFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "lsconf")
+	if err != nil {
+		t.Error(err)
+	}
+
+	path := f.Name()
+	defer os.Remove(path)
+
+	err = removeInputOutput(path)
+	if err != nil {
+		t.Error(err)
+	}
+
+	data, err := ioutil.ReadFile(path)
+    if err != nil {
+        t.Error(err)
+    }
+
+	t.Logf("CONFIG IS: %s", data)
+}

--- a/logstash/pipelineconfigdir_test.go
+++ b/logstash/pipelineconfigdir_test.go
@@ -9,7 +9,10 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
+
+	"github.com/magnusbaeck/logstash-filter-verifier/testhelpers"
 )
 
 func TestGetPipelineConfigDir(t *testing.T) {
@@ -56,7 +59,7 @@ func TestGetPipelineConfigDir(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test %d: Unexpected error when creating temp dir: %s", i, err)
 			}
-			err = ioutil.WriteFile(filepath.Join(tempdir, f), []byte(filepath.Base(f)), 0644)
+			err = ioutil.WriteFile(filepath.Join(tempdir, f), []byte(""), 0644)
 			if err != nil {
 				t.Fatalf("Test %d: Unexpected error when writing to temp file: %s", i, err)
 			}
@@ -99,9 +102,8 @@ func TestGetPipelineConfigDir(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test %d: Unexpected error when reading file: %s", i, err)
 			}
-			if f != string(buf) {
-				t.Errorf("Test %d:\nExpected file contents:\n%#v\nGot:\n%#v", i, f, string(buf))
-			}
+
+			testhelpers.AssertEqual(t, "", string(buf))
 		}
 	}
 }
@@ -191,11 +193,13 @@ func TestRemoveInputOutputBasicConfig(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadFile(path)
-    if err != nil {
-        t.Error(err)
-    }
+	if err != nil {
+		t.Error(err)
+	}
 
-	t.Logf("CONFIG IS: %s", data)
+
+	actual := strings.Replace(string(data), "\n","",-1)
+	testhelpers.AssertEqual(t, "filter {  grok {      }}", actual)
 }
 
 func TestRemoveInputOutputEmptyFile(t *testing.T) {
@@ -213,9 +217,9 @@ func TestRemoveInputOutputEmptyFile(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadFile(path)
-    if err != nil {
-        t.Error(err)
-    }
+	if err != nil {
+		t.Error(err)
+	}
 
-	t.Logf("CONFIG IS: %s", data)
+	testhelpers.AssertEqual(t, "", string(data))
 }

--- a/testhelpers/compare.go
+++ b/testhelpers/compare.go
@@ -17,3 +17,11 @@ func CompareErrors(t *testing.T, idx int, expected, actual error) {
 		t.Errorf("Test %d: Expected result:\n%#v\nGot:\n%#v", idx, expected, actual)
 	}
 }
+
+// AssertEqual compares any two values and reports an error if their
+// values are not equal.
+func AssertEqual(t *testing.T, expected interface{}, actual interface{}) {
+	if expected != actual {
+		t.Errorf("%v != %v", expected, actual)
+	}
+}


### PR DESCRIPTION
This RP automatically removes the input and output config sections when copying over the logstash config file(s), which will allow testing the actual configuration that is being used.

Ref #10 