### PR TITLE
Known limitations -1: Add YAML support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: go
+go_import_path: github.com/magnusbaeck/logstash-filter-verifier
 go:
   - 1.8
 script:

--- a/Godeps
+++ b/Godeps
@@ -8,3 +8,4 @@ github.com/mattn/go-shellwords                        f4e566c536cf
 github.com/mitchellh/packer                           v0.9.0
 github.com/op/go-logging                              dfaf3dff9b63
 gopkg.in/matm/v1/gocov-html                           v1.0
+gopkg.in/yaml.v2                                      v2.2.1

--- a/README.md
+++ b/README.md
@@ -244,11 +244,16 @@ This command only works for test case files, where for every line in
 
 ## Migrate testcase files from JSON to YAML format
 
+To migrate test case files from JSON format to YAML, run this command
+in the directory containing the test case files:
+
 ```
 for f in $(ls -1 *.json) ; do \
     ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read))' < "$f" > "${f%.json}.yml"
 done
 ```
+
+It won't remove your original files. Please move or delete them yourself.
 
 ## Notes about the flag --sockets
 

--- a/logstash-filter-verifier.go
+++ b/logstash-filter-verifier.go
@@ -270,7 +270,7 @@ func mainEntrypoint() int {
 
 	level, err := oplogging.LogLevel(*loglevel)
 	if err != nil {
-		prefixedUserError("Bad loglevel: %s", loglevel)
+		prefixedUserError("Bad loglevel: %v", loglevel)
 		return 1
 	}
 	logging.SetLevel(level)

--- a/testcase/discover.go
+++ b/testcase/discover.go
@@ -21,9 +21,9 @@ func inList(allowed []string, search string) (result bool) {
 	return false
 }
 
-// DiscoverTests reads a test case JSON file and returns a slice of
+// DiscoverTests reads a test case JSON or YAML file and returns a slice of
 // TestCase structs or, if the input path is a directory, reads all
-// .json files in that directory and returns them as TestCase
+// .json/.yaml/.yml files in that directory and returns them as TestCase
 // structs.
 func DiscoverTests(path string) ([]TestCaseSet, error) {
 	pathinfo, err := os.Stat(path)

--- a/testcase/discover.go
+++ b/testcase/discover.go
@@ -12,7 +12,7 @@ import (
 
 // DiscoverTests reads a test case JSON file and returns a slice of
 // TestCase structs or, if the input path is a directory, reads all
-// .json files in that directorory and returns them as TestCase
+// .json files in that directory and returns them as TestCase
 // structs.
 func DiscoverTests(path string) ([]TestCaseSet, error) {
 	pathinfo, err := os.Stat(path)

--- a/testcase/discover.go
+++ b/testcase/discover.go
@@ -10,6 +10,17 @@ import (
 	"strings"
 )
 
+var supportedFileExtensions = []string{"json", "yml", "yaml"}
+
+func inList(allowed []string, search string) (result bool) {
+	for _, allowedEntry := range allowed {
+		if search == allowedEntry {
+			return true
+		}
+	}
+	return false
+}
+
 // DiscoverTests reads a test case JSON file and returns a slice of
 // TestCase structs or, if the input path is a directory, reads all
 // .json files in that directory and returns them as TestCase
@@ -31,11 +42,23 @@ func discoverTestDirectory(path string) ([]TestCaseSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error discovering test case files: %s", err)
 	}
+
 	var result []TestCaseSet
 	for _, f := range files {
-		if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
+		if f.IsDir() {
 			continue
 		}
+
+		extensionCaseInsensitive := strings.ToLower(filepath.Ext(f.Name()))
+		if len(extensionCaseInsensitive) == 0 {
+			continue
+		}
+
+		extensionDotlessCaseInsensitive := extensionCaseInsensitive[1:]
+		if !inList(supportedFileExtensions, extensionDotlessCaseInsensitive) {
+			continue
+		}
+
 		fullpath := filepath.Join(path, f.Name())
 		tcs, err := NewFromFile(fullpath)
 		if err != nil {

--- a/testcase/discover_test.go
+++ b/testcase/discover_test.go
@@ -40,9 +40,24 @@ func TestDiscoverTests_Directory(t *testing.T) {
 			[]string{"test1.json", "test2.json"},
 		},
 		{
-			[]string{"otherfile.txt", "test1.json", "test2.json"},
+			[]string{"test1.yml", "test2.yml"},
 			[]string{},
-			[]string{"test1.json", "test2.json"},
+			[]string{"test1.yml", "test2.yml"},
+		},
+		{
+			[]string{"test1.yaml", "test2.yaml"},
+			[]string{},
+			[]string{"test1.yaml", "test2.yaml"},
+		},
+		{
+			[]string{"test1.json", "test2.yml", "test3.yaml"},
+			[]string{},
+			[]string{"test1.json", "test2.yml", "test3.yaml"},
+		},
+		{
+			[]string{"otherfile.txt", "test1.json", "test2.yaml"},
+			[]string{},
+			[]string{"test1.json", "test2.yaml"},
 		},
 	}
 	for cnum, c := range cases {

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -18,7 +18,7 @@ import (
 )
 
 // TestCaseSet contains the configuration of a Logstash filter test case.
-// Most of the fields are supplied by the user via a JSON file.
+// Most of the fields are supplied by the user via a JSON or YAML file.
 type TestCaseSet struct {
 	// File is the absolute path to the file from which this
 	// test case was read.

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -5,9 +5,6 @@ package testcase
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/magnusbaeck/logstash-filter-verifier/logging"
-	"github.com/magnusbaeck/logstash-filter-verifier/logstash"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
@@ -15,6 +12,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+
+	"github.com/magnusbaeck/logstash-filter-verifier/logging"
+	"github.com/magnusbaeck/logstash-filter-verifier/logstash"
+	"gopkg.in/yaml.v2"
 )
 
 // TestCaseSet contains the configuration of a Logstash filter test case.

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -31,7 +31,7 @@ type TestCaseSet struct {
 
 	// IgnoredFields contains a list of fields that will be
 	// deleted from the events that Logstash returns before
-	// they're compared to the events in ExpectedEevents.
+	// they're compared to the events in ExpectedEvents.
 	//
 	// This can be used for skipping fields that Logstash
 	// populates with unpredictable contents (hostnames or

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -5,12 +5,13 @@ package testcase
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/magnusbaeck/logstash-filter-verifier/logstash"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/magnusbaeck/logstash-filter-verifier/logstash"
 )
 
 func TestNew(t *testing.T) {

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -174,7 +174,7 @@ func TestCompare(t *testing.T) {
 		// Empty test case with no messages is okay.
 		{
 			&TestCaseSet{
-				File: "/path/to/filename.json",
+				File: "/path/to/filename.yml",
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
@@ -189,7 +189,7 @@ func TestCompare(t *testing.T) {
 		// Too few messages received.
 		{
 			&TestCaseSet{
-				File: "/path/to/filename.json",
+				File: "/path/to/filename.yml",
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
@@ -219,7 +219,7 @@ func TestCompare(t *testing.T) {
 		// Too many messages received.
 		{
 			&TestCaseSet{
-				File: "/path/to/filename.json",
+				File: "/path/to/filename.yml",
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
@@ -249,7 +249,7 @@ func TestCompare(t *testing.T) {
 		// Different fields.
 		{
 			&TestCaseSet{
-				File: "/path/to/filename.json",
+				File: "/path/to/filename.yml",
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
@@ -286,7 +286,7 @@ func TestCompare(t *testing.T) {
 		// Same field with different values.
 		{
 			&TestCaseSet{
-				File: "/path/to/filename.json",
+				File: "/path/to/filename.yml",
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
@@ -323,7 +323,7 @@ func TestCompare(t *testing.T) {
 		// Ignored fields are ignored.
 		{
 			&TestCaseSet{
-				File: "/path/to/filename.json",
+				File: "/path/to/filename.yml",
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},
@@ -348,7 +348,7 @@ func TestCompare(t *testing.T) {
 		// Diff command execution errors are propagated correctly.
 		{
 			&TestCaseSet{
-				File: "/path/to/filename.json",
+				File: "/path/to/filename.yml",
 				InputFields: logstash.FieldSet{
 					"type": "test",
 				},


### PR DESCRIPTION
As already stated by @magnusbaeck in the _Known Limitations_, supporting YAML (superset of JSON) would be nice, especially to get around the need to always escape quotes in JSON input objects. This PR adds this support as well as a short section in the README how to convert already present testcases in JSON format to YAML. Enjoy. :)