### PR TITLE
Add YAML support and dot notation for fields, exclude and input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /dist/
 /logstash-filter-verifier
 *.coverprofile
+
+/tests/

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,5 @@ require (
 	github.com/mikefarah/yaml/v2 v2.4.0
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,11 @@ require (
 	github.com/axw/gocov v1.0.0
 	github.com/breml/logstash-config v0.1.0
 	github.com/go-playground/overalls v0.0.0-20180201144345-22ec1a223b7c
+	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/packer v1.4.4
-	github.com/matm/gocov-html v0.0.0-20160206185555-f6dd0fd0ebc7
+	github.com/matm/gocov-html v0.0.0-20191111163307-9ee104d84c82
 	github.com/mattn/go-shellwords v1.0.6
+	github.com/mikefarah/yaml/v2 v2.4.0
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-	github.com/yookoala/realpath v1.0.0 // indirect
-	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
+	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786/go.mod h1:kCEb
 github.com/masterzen/winrm v0.0.0-20180224160350-7e40f93ae939/go.mod h1:CfZSN7zwz5gJiFhZJz49Uzk7mEBHIceWmbFmYx7Hf7E=
 github.com/matm/gocov-html v0.0.0-20160206185555-f6dd0fd0ebc7 h1:IpusRbIZ1Z5j96YpxRD7vTwpfR7Cv3vgETmilcHF5BE=
 github.com/matm/gocov-html v0.0.0-20160206185555-f6dd0fd0ebc7/go.mod h1:2amKdhwK7Jz2kRhLYmUH2NIOeBs6Tmhpy5UgDXhRbHc=
+github.com/matm/gocov-html v0.0.0-20191111163307-9ee104d84c82 h1:pMb6HhXFlcC2qHIx7Z++2nRhgQ+5kQx8wLbMqBpuU6U=
+github.com/matm/gocov-html v0.0.0-20191111163307-9ee104d84c82/go.mod h1:zha4ZSIA/qviBBKx3j6tJG/Lx6aIdjOXPWuKAcJchQM=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -186,6 +188,8 @@ github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.1/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/mikefarah/yaml/v2 v2.4.0 h1:eYqfooY0BnvKTJxr7+ABJs13n3dg9n347GScDaU2Lww=
+github.com/mikefarah/yaml/v2 v2.4.0/go.mod h1:ahVqZF4n1W4NqwvVnZzC4es67xsW9uR/RRf2RRxieJU=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-fs v0.0.0-20180402234041-7b48fa161ea7/go.mod h1:g7SZj7ABpStq3tM4zqHiVEG5un/DZ1+qJJKO7qx1EvU=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -218,6 +222,7 @@ github.com/packer-community/winrmcp v0.0.0-20180921204643-0fd363d6159a/go.mod h1
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v0.0.0-20160118190721-e84cc8c755ca/go.mod h1:NxmoDg/QLVWluQDUYG7XBZTLUpKeFa8e3aMf1BfjyHk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -365,6 +370,8 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/testcase/discover.go
+++ b/testcase/discover.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	oplogging "github.com/op/go-logging"
 )
 
 // DiscoverTests reads a test case JSON file or YAML file and returns a slice of
@@ -33,12 +35,18 @@ func discoverTestDirectory(path string) ([]TestCaseSet, error) {
 	}
 	var result []TestCaseSet
 	for _, f := range files {
-		log.Debugf("Read file: %s", f.Name())
+		if log.IsEnabledFor(oplogging.DEBUG) {
+			log.Debugf("Read file: %s", f.Name())
+		}
+
 		if f.IsDir() || (!strings.HasSuffix(f.Name(), ".json") && !strings.HasSuffix(f.Name(), ".yaml")) {
 			continue
 		}
 		fullpath := filepath.Join(path, f.Name())
-		log.Debugf("Read file fullpath: %s", fullpath)
+
+		if log.IsEnabledFor(oplogging.DEBUG) {
+			log.Debugf("Read file fullpath: %s", fullpath)
+		}
 		tcs, err := NewFromFile(fullpath)
 		if err != nil {
 			return nil, err

--- a/testcase/discover.go
+++ b/testcase/discover.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 )
 
-// DiscoverTests reads a test case JSON file and returns a slice of
+// DiscoverTests reads a test case JSON file or YAML file and returns a slice of
 // TestCase structs or, if the input path is a directory, reads all
-// .json files in that directorory and returns them as TestCase
+// .json or .yaml files in that directorory and returns them as TestCase
 // structs.
 func DiscoverTests(path string) ([]TestCaseSet, error) {
 	pathinfo, err := os.Stat(path)
@@ -33,10 +33,12 @@ func discoverTestDirectory(path string) ([]TestCaseSet, error) {
 	}
 	var result []TestCaseSet
 	for _, f := range files {
-		if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
+		log.Debugf("Read file: %s", f.Name())
+		if f.IsDir() || (!strings.HasSuffix(f.Name(), ".json") && !strings.HasSuffix(f.Name(), ".yaml")) {
 			continue
 		}
 		fullpath := filepath.Join(path, f.Name())
+		log.Debugf("Read file fullpath: %s", fullpath)
 		tcs, err := NewFromFile(fullpath)
 		if err != nil {
 			return nil, err

--- a/testcase/discover.go
+++ b/testcase/discover.go
@@ -14,7 +14,7 @@ import (
 
 // DiscoverTests reads a test case JSON file or YAML file and returns a slice of
 // TestCase structs or, if the input path is a directory, reads all
-// .json or .yaml files in that directorory and returns them as TestCase
+// .json or .yaml or .yml files in that directorory and returns them as TestCase
 // structs.
 func DiscoverTests(path string) ([]TestCaseSet, error) {
 	pathinfo, err := os.Stat(path)
@@ -39,7 +39,7 @@ func discoverTestDirectory(path string) ([]TestCaseSet, error) {
 			log.Debugf("Read file: %s", f.Name())
 		}
 
-		if f.IsDir() || (!strings.HasSuffix(f.Name(), ".json") && !strings.HasSuffix(f.Name(), ".yaml")) {
+		if f.IsDir() || (!strings.HasSuffix(f.Name(), ".json") && !strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".yml")) {
 			continue
 		}
 		fullpath := filepath.Join(path, f.Name())

--- a/testcase/discover_test.go
+++ b/testcase/discover_test.go
@@ -20,29 +20,29 @@ func TestDiscoverTests_Directory(t *testing.T) {
 		expected []string
 	}{
 		{
-			[]string{},
-			[]string{},
-			[]string{},
+			files:    []string{},
+			dirs:     []string{},
+			expected: []string{},
 		},
 		{
-			[]string{},
-			[]string{"dir1", "dir2"},
-			[]string{},
+			files:    []string{},
+			dirs:     []string{"dir1", "dir2"},
+			expected: []string{},
 		},
 		{
-			[]string{"otherfile.txt", ".dotfile"},
-			[]string{},
-			[]string{},
+			files:    []string{"otherfile.txt", ".dotfile"},
+			dirs:     []string{},
+			expected: []string{},
 		},
 		{
-			[]string{"test1.json", "test2.json"},
-			[]string{},
-			[]string{"test1.json", "test2.json"},
+			files:    []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml"},
+			dirs:     []string{},
+			expected: []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml"},
 		},
 		{
-			[]string{"otherfile.txt", "test1.json", "test2.json"},
-			[]string{},
-			[]string{"test1.json", "test2.json"},
+			files:    []string{"otherfile.txt", "test1.json", "test2.json", "test1.yaml", "test2.yaml"},
+			dirs:     []string{},
+			expected: []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml"},
 		},
 	}
 	for cnum, c := range cases {
@@ -105,7 +105,9 @@ func TestDiscoverTests_Directory(t *testing.T) {
 // TestDiscoverTests_File tests passing the path to a single file to
 // DiscoverTests.
 func TestDiscoverTests_File(t *testing.T) {
-	tempfile, err := ioutil.TempFile("", "")
+
+	// With JSON file
+	tempfile, err := ioutil.TempFile("", "*.json")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -118,6 +120,32 @@ func TestDiscoverTests_File(t *testing.T) {
 	}
 
 	testcases, err := DiscoverTests(tempfile.Name())
+	if err != nil {
+		t.Fatalf("DiscoverTests() unexpectedly returned an error: %s", err)
+	}
+
+	if len(testcases) != 1 {
+		t.Fatalf("DiscoverTests() unexpectedly returned %d test cases: %+v", len(testcases), testcases)
+	}
+
+	if testcases[0].File != tempfile.Name() {
+		t.Fatalf("DiscoverTests() unexpectedly returned %d test cases: %+v", len(testcases), testcases)
+	}
+
+	// With YAML file
+	tempfile, err = ioutil.TempFile("", "*.yaml")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer func() {
+		tempfile.Close()
+		os.Remove(tempfile.Name())
+	}()
+	if err = ioutil.WriteFile(tempfile.Name(), []byte(`{"type": "test"}`), 0644); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	testcases, err = DiscoverTests(tempfile.Name())
 	if err != nil {
 		t.Fatalf("DiscoverTests() unexpectedly returned an error: %s", err)
 	}

--- a/testcase/discover_test.go
+++ b/testcase/discover_test.go
@@ -35,14 +35,14 @@ func TestDiscoverTests_Directory(t *testing.T) {
 			expected: []string{},
 		},
 		{
-			files:    []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml"},
+			files:    []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml", "test1.yml", "test2.yml"},
 			dirs:     []string{},
-			expected: []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml"},
+			expected: []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml", "test1.yml", "test2.yml"},
 		},
 		{
-			files:    []string{"otherfile.txt", "test1.json", "test2.json", "test1.yaml", "test2.yaml"},
+			files:    []string{"otherfile.txt", "test1.json", "test2.json", "test1.yaml", "test2.yaml", "test1.yml", "test2.yml"},
 			dirs:     []string{},
-			expected: []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml"},
+			expected: []string{"test1.json", "test2.json", "test1.yaml", "test2.yaml", "test1.yml", "test2.yml"},
 		},
 	}
 	for cnum, c := range cases {
@@ -134,6 +134,32 @@ func TestDiscoverTests_File(t *testing.T) {
 
 	// With YAML file
 	tempfile, err = ioutil.TempFile("", "*.yaml")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer func() {
+		tempfile.Close()
+		os.Remove(tempfile.Name())
+	}()
+	if err = ioutil.WriteFile(tempfile.Name(), []byte(`{"type": "test"}`), 0644); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	testcases, err = DiscoverTests(tempfile.Name())
+	if err != nil {
+		t.Fatalf("DiscoverTests() unexpectedly returned an error: %s", err)
+	}
+
+	if len(testcases) != 1 {
+		t.Fatalf("DiscoverTests() unexpectedly returned %d test cases: %+v", len(testcases), testcases)
+	}
+
+	if testcases[0].File != tempfile.Name() {
+		t.Fatalf("DiscoverTests() unexpectedly returned %d test cases: %+v", len(testcases), testcases)
+	}
+
+	// With YML file
+	tempfile, err = ioutil.TempFile("", "*.yml")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/testcase/helper.go
+++ b/testcase/helper.go
@@ -12,9 +12,9 @@ func parseAllDotProperties(data map[string]interface{}) map[string]interface{} {
 	for k, v := range data {
 		rv := reflect.ValueOf(v)
 		if rv.Kind() == reflect.Map {
-			parseDotPropertie(k, parseAllDotProperties(v.(map[string]interface{})), result)
+			parseDotProperty(k, parseAllDotProperties(v.(map[string]interface{})), result)
 		} else {
-			parseDotPropertie(k, v, result)
+			parseDotProperty(k, v, result)
 		}
 	}
 
@@ -22,18 +22,17 @@ func parseAllDotProperties(data map[string]interface{}) map[string]interface{} {
 }
 
 // parseDotPropertie handle the recursivity to transform attribute that contain dot in sub structure
-func parseDotPropertie(key string, value interface{}, result map[string]interface{}) {
+func parseDotProperty(key string, value interface{}, result map[string]interface{}) {
 	if strings.Contains(key, ".") {
 		listKey := strings.Split(key, ".")
 		if _, ok := result[listKey[0]]; !ok {
 			result[listKey[0]] = make(map[string]interface{})
 		}
-		parseDotPropertie(strings.Join(listKey[1:], "."), value, result[listKey[0]].(map[string]interface{}))
+		parseDotProperty(strings.Join(listKey[1:], "."), value, result[listKey[0]].(map[string]interface{}))
 	} else {
 		result[key] = value
 	}
 }
-
 
 // removeFields handle the supression of needed key before compare result and expected data
 func removeFields(keys []string, data map[string]interface{}) map[string]interface{} {

--- a/testcase/helper.go
+++ b/testcase/helper.go
@@ -60,5 +60,6 @@ func removeField(keys []string, data map[string]interface{}) map[string]interfac
 		return data
 	}
 
-	return removeField(keys[1:], val.(map[string]interface{}))
+	data[keys[0]] = removeField(keys[1:], val.(map[string]interface{}))
+	return data
 }

--- a/testcase/helper.go
+++ b/testcase/helper.go
@@ -60,6 +60,12 @@ func removeField(keys []string, data map[string]interface{}) map[string]interfac
 		return data
 	}
 
-	data[keys[0]] = removeField(keys[1:], val.(map[string]interface{}))
+	cleanData := removeField(keys[1:], val.(map[string]interface{}))
+	if len(cleanData) > 0 {
+		data[keys[0]] = cleanData
+	} else {
+		delete(data, keys[0])
+	}
+
 	return data
 }

--- a/testcase/helper.go
+++ b/testcase/helper.go
@@ -34,13 +34,9 @@ func parseDotPropertie(key string, value interface{}, result map[string]interfac
 	}
 }
 
+
+// removeFields handle the supression of needed key before compare result and expected data
 func removeFields(keys []string, data map[string]interface{}) map[string]interface{} {
-
-	return removeField(keys, data)
-
-}
-
-func removeField(keys []string, data map[string]interface{}) map[string]interface{} {
 
 	// last item
 	if len(keys) == 1 {
@@ -60,7 +56,7 @@ func removeField(keys []string, data map[string]interface{}) map[string]interfac
 		return data
 	}
 
-	cleanData := removeField(keys[1:], val.(map[string]interface{}))
+	cleanData := removeFields(keys[1:], val.(map[string]interface{}))
 	if len(cleanData) > 0 {
 		data[keys[0]] = cleanData
 	} else {

--- a/testcase/helper.go
+++ b/testcase/helper.go
@@ -1,0 +1,64 @@
+package testcase
+
+import (
+	"reflect"
+	"strings"
+)
+
+// parseAllDotProperties permit to convert attributes with dot in sub structure
+func parseAllDotProperties(data map[string]interface{}) map[string]interface{} {
+
+	result := make(map[string]interface{})
+	for k, v := range data {
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Map {
+			parseDotPropertie(k, parseAllDotProperties(v.(map[string]interface{})), result)
+		} else {
+			parseDotPropertie(k, v, result)
+		}
+	}
+
+	return result
+}
+
+// parseDotPropertie handle the recursivity to transform attribute that contain dot in sub structure
+func parseDotPropertie(key string, value interface{}, result map[string]interface{}) {
+	if strings.Contains(key, ".") {
+		listKey := strings.Split(key, ".")
+		if _, ok := result[listKey[0]]; !ok {
+			result[listKey[0]] = make(map[string]interface{})
+		}
+		parseDotPropertie(strings.Join(listKey[1:], "."), value, result[listKey[0]].(map[string]interface{}))
+	} else {
+		result[key] = value
+	}
+}
+
+func removeFields(keys []string, data map[string]interface{}) map[string]interface{} {
+
+	return removeField(keys, data)
+
+}
+
+func removeField(keys []string, data map[string]interface{}) map[string]interface{} {
+
+	// last item
+	if len(keys) == 1 {
+		delete(data, keys[0])
+		return data
+	}
+
+	//else recurse
+	val, ok := data[keys[0]]
+	if !ok {
+		return data
+	}
+
+	// Value is map
+	rv := reflect.ValueOf(val)
+	if rv.Kind() != reflect.Map {
+		return data
+	}
+
+	return removeField(keys[1:], val.(map[string]interface{}))
+}

--- a/testcase/helper_test.go
+++ b/testcase/helper_test.go
@@ -1,0 +1,236 @@
+package testcase
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestParseDotProperty test keys that contain dot or bracket notation are converted to sub structure
+func TestParseDotProperty(t *testing.T) {
+
+	var (
+		key      string
+		value    string
+		result   map[string]interface{}
+		expected map[string]interface{}
+	)
+
+	// Create sub structure with dot notation
+	key = "log.file.path"
+	value = "/tmp/test.log"
+	result = make(map[string]interface{})
+	expected = map[string]interface{}{
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/test.log",
+			},
+		},
+	}
+	parseDotProperty(key, value, result)
+	assert.Equal(t, expected, result)
+
+	// Create sub structure with bracket notation
+	key = "[log][file][path]"
+	value = "/tmp/test.log"
+	result = make(map[string]interface{})
+	expected = map[string]interface{}{
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/test.log",
+			},
+		},
+	}
+	parseDotProperty(key, value, result)
+	assert.Equal(t, expected, result)
+
+	// Do nothin when no brancket and not dot
+	key = "message"
+	value = "/tmp/test.log"
+	result = make(map[string]interface{})
+	expected = map[string]interface{}{
+		"message": "/tmp/test.log",
+	}
+	parseDotProperty(key, value, result)
+	assert.Equal(t, expected, result)
+}
+
+// TestParseAllDotProperties test that all keys on map that contain dot or bracket notation are converted on sub structure
+func TestParseAllDotProperties(t *testing.T) {
+
+	data := map[string]interface{}{
+		"message":             "my message",
+		"log.file.path":       "/tmp/test.log",
+		"[log][origin][line]": 2,
+	}
+	expected := map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/test.log",
+			},
+			"origin": map[string]interface{}{
+				"line": 2,
+			},
+		},
+	}
+
+	result := parseAllDotProperties(data)
+	assert.Equal(t, expected, result)
+
+}
+
+// TestRemoveField test that ignore fields are removed from actual events
+// It support dot and bracket notation
+func TestRemoveField(t *testing.T) {
+
+	var (
+		keys     []string
+		data     map[string]interface{}
+		expected map[string]interface{}
+	)
+
+	// Test without specific notation
+	keys = []string{
+		"message",
+	}
+	data = map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+			},
+		},
+		"source": "test",
+	}
+	expected = map[string]interface{}{
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+			},
+		},
+		"source": "test",
+	}
+	removeField(keys, data)
+	assert.Equal(t, expected, data)
+
+	// Test when keys is sub item and is the last item
+	data = map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+			},
+		},
+		"source": "test",
+	}
+	keys = []string{
+		"log",
+		"file",
+		"path",
+	}
+	expected = map[string]interface{}{
+		"message": "my message",
+		"source":  "test",
+	}
+	removeField(keys, data)
+	assert.Equal(t, expected, data)
+
+	// Test when keys is sub item and is stay brother fields
+	data = map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+				"size": "test",
+			},
+		},
+		"source": "test",
+	}
+	keys = []string{
+		"log",
+		"file",
+		"path",
+	}
+	expected = map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"size": "test",
+			},
+		},
+		"source": "test",
+	}
+	removeField(keys, data)
+	assert.Equal(t, expected, data)
+
+}
+
+// TestRemoveFields test that ignore field are removed from actual events
+// It support dot and bracket notation
+func TestRemoveFields(t *testing.T) {
+
+	var (
+		key      string
+		data     map[string]interface{}
+		expected map[string]interface{}
+	)
+
+	// Test without specific notation
+	key = "message"
+	data = map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+			},
+		},
+		"source": "test",
+	}
+	expected = map[string]interface{}{
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+			},
+		},
+		"source": "test",
+	}
+	removeFields(key, data)
+	assert.Equal(t, expected, data)
+
+	// Test when keys with dot notation
+	data = map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+			},
+		},
+		"source": "test",
+	}
+	key = "log.file.path"
+	expected = map[string]interface{}{
+		"message": "my message",
+		"source":  "test",
+	}
+	removeFields(key, data)
+	assert.Equal(t, expected, data)
+
+	// Test when keys with bracket notation
+	data = map[string]interface{}{
+		"message": "my message",
+		"log": map[string]interface{}{
+			"file": map[string]interface{}{
+				"path": "/tmp/file.log",
+			},
+		},
+		"source": "test",
+	}
+	key = "[log][file][path]"
+	expected = map[string]interface{}{
+		"message": "my message",
+		"source":  "test",
+	}
+	removeFields(key, data)
+	assert.Equal(t, expected, data)
+
+}

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -113,7 +113,9 @@ var (
 	defaultIgnoredFields = []string{"@version"}
 )
 
-func (t *TestCaseSet) convertDotFileds() error {
+// convertDotFields permit to replace keys that contains dot with sub structure.
+// For example, the key `log.file.path` will be convert by `"log": {"file": {"path": "VALUE"}}`
+func (t *TestCaseSet) convertDotFields() error {
 
 	// Convert fields in input fields
 	t.InputFields = parseAllDotProperties(t.InputFields)
@@ -190,7 +192,7 @@ func New(reader io.Reader, configType string) (*TestCaseSet, error) {
 	}
 
 	// Convert dot fields
-	if err := tcs.convertDotFileds(); err != nil {
+	if err := tcs.convertDotFields(); err != nil {
 		return nil, err
 	}
 

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -19,6 +19,7 @@ import (
 	"github.com/magnusbaeck/logstash-filter-verifier/logging"
 	"github.com/magnusbaeck/logstash-filter-verifier/logstash"
 	"github.com/mikefarah/yaml/v2"
+	oplogging "github.com/op/go-logging"
 	"github.com/pkg/errors"
 )
 
@@ -196,7 +197,9 @@ func New(reader io.Reader, configType string) (*TestCaseSet, error) {
 		return nil, err
 	}
 
-	log.Debugf("%+v", tcs)
+	if log.IsEnabledFor(oplogging.DEBUG) {
+		log.Debugf("%+v", tcs)
+	}
 
 	return &tcs, nil
 }
@@ -208,9 +211,12 @@ func NewFromFile(path string) (*TestCaseSet, error) {
 		return nil, err
 	}
 	ext := strings.TrimPrefix(filepath.Ext(abspath), ".")
-	log.Debugf("File extension: %s", ext)
 
-	log.Debug("Reading test case file: %s (%s)", path, abspath)
+	if log.IsEnabledFor(oplogging.DEBUG) {
+		log.Debugf("File extension: %s", ext)
+		log.Debug("Reading test case file: %s (%s)", path, abspath)
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -194,6 +194,8 @@ func New(reader io.Reader, configType string) (*TestCaseSet, error) {
 		return nil, err
 	}
 
+	log.Debugf("%+v", tcs)
+
 	return &tcs, nil
 }
 

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -198,7 +198,7 @@ func New(reader io.Reader, configType string) (*TestCaseSet, error) {
 	}
 
 	if log.IsEnabledFor(oplogging.DEBUG) {
-		log.Debugf("%+v", tcs)
+		log.Debugf("Current TestCaseSet after convert fiedls: %+v", tcs)
 	}
 
 	return &tcs, nil

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -10,24 +10,28 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	unjson "github.com/hashicorp/packer/common/json"
 	"github.com/magnusbaeck/logstash-filter-verifier/logging"
 	"github.com/magnusbaeck/logstash-filter-verifier/logstash"
+	"github.com/mikefarah/yaml/v2"
+	"github.com/pkg/errors"
 )
 
 // TestCaseSet contains the configuration of a Logstash filter test case.
-// Most of the fields are supplied by the user via a JSON file.
+// Most of the fields are supplied by the user via a JSON file or YAML file.
 type TestCaseSet struct {
 	// File is the absolute path to the file from which this
 	// test case was read.
-	File string `json:"-"`
+	File string `json:"-" yaml:"-"`
 
 	// Codec names the Logstash codec that should be used when
 	// events are read. This is normally "line" or "json_lines".
-	Codec string `json:"codec"`
+	Codec string `json:"codec" yaml:"codec"`
 
 	// IgnoredFields contains a list of fields that will be
 	// deleted from the events that Logstash returns before
@@ -41,31 +45,31 @@ type TestCaseSet struct {
 	// It's also useful for the @version field that Logstash
 	// always adds with a constant value so that one doesn't have
 	// to include that field in every event in ExpectedEvents.
-	IgnoredFields []string `json:"ignore"`
+	IgnoredFields []string `json:"ignore" yaml:"ignore"`
 
 	// InputFields contains a mapping of fields that should be
 	// added to input events, like "type" or "tags". The map
 	// values may be scalar values or arrays of scalar
 	// values. This is often important since filters typically are
 	// configured based on the event's type or its tags.
-	InputFields logstash.FieldSet `json:"fields"`
+	InputFields logstash.FieldSet `json:"fields" yaml:"fields"`
 
 	// InputLines contains the lines of input that should be fed
 	// to the Logstash process.
-	InputLines []string `json:"input"`
+	InputLines []string `json:"input" yaml:"input"`
 
 	// ExpectedEvents contains a slice of expected events to be
 	// compared to the actual events produced by the Logstash
 	// process.
-	ExpectedEvents []logstash.Event `json:"expected"`
+	ExpectedEvents []logstash.Event `json:"expected" yaml:"expected"`
 
 	// TestCases is a slice of test cases, which include at minimum
 	// a pair of an input and an expected event
 	// Optionally other information regarding the test case
 	// may be supplied.
-	TestCases []TestCase `json:"testcases"`
+	TestCases []TestCase `json:"testcases" yaml:"testcases"`
 
-	descriptions []string
+	descriptions []string `json:"descriptions" yaml:"descriptions"`
 }
 
 // TestCase is a pair of an input line that should be fed
@@ -74,16 +78,16 @@ type TestCaseSet struct {
 type TestCase struct {
 	// InputLines contains the lines of input that should be fed
 	// to the Logstash process.
-	InputLines []string `json:"input"`
+	InputLines []string `json:"input" yaml:"input"`
 
 	// ExpectedEvents contains a slice of expected events to be
 	// compared to the actual events produced by the Logstash
 	// process.
-	ExpectedEvents []logstash.Event `json:"expected"`
+	ExpectedEvents []logstash.Event `json:"expected" yaml:"expected"`
 
 	// Description contains an optional description of the test case
 	// which will be printed while the tests are executed.
-	Description string `json:"description"`
+	Description string `json:"description" yaml:"description"`
 }
 
 // ComparisonError indicates that there was a mismatch when the
@@ -109,11 +113,47 @@ var (
 	defaultIgnoredFields = []string{"@version"}
 )
 
+func (t *TestCaseSet) convertDotFileds() error {
+
+	// Convert fields in input fields
+	t.InputFields = parseAllDotProperties(t.InputFields)
+
+	// Convert fields in expected events
+	for i, expected := range t.ExpectedEvents {
+		t.ExpectedEvents[i] = parseAllDotProperties(expected)
+	}
+
+	// Convert  fields in input json string
+	if t.Codec == "json_lines" {
+		for i, line := range t.InputLines {
+			var jsonObj map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &jsonObj); err != nil {
+				return err
+			}
+			jsonObj = parseAllDotProperties(jsonObj)
+			data, err := json.Marshal(jsonObj)
+			if err != nil {
+				return err
+			}
+			t.InputLines[i] = string(data)
+		}
+	}
+
+	return nil
+
+}
+
 // New reads a test case configuration from a reader and returns a
 // TestCase. Defaults to a "line" codec and ignoring the @version
 // field. If the configuration being read lists additional fields to
 // ignore those will be ignored in addition to @version.
-func New(reader io.Reader) (*TestCaseSet, error) {
+// configType must be json or yaml.
+func New(reader io.Reader, configType string) (*TestCaseSet, error) {
+
+	if configType != "json" && configType != "yaml" {
+		return nil, errors.New("Config type must be json or yaml")
+	}
+
 	tcs := TestCaseSet{
 		Codec:       "line",
 		InputFields: logstash.FieldSet{},
@@ -122,9 +162,19 @@ func New(reader io.Reader) (*TestCaseSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = unjson.Unmarshal(buf, &tcs); err != nil {
-		return nil, err
+
+	if configType == "json" {
+		if err = unjson.Unmarshal(buf, &tcs); err != nil {
+			return nil, err
+		}
+	} else {
+		// Fix issue https://github.com/go-yaml/yaml/issues/139
+		yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
+		if err = yaml.Unmarshal(buf, &tcs); err != nil {
+			return nil, err
+		}
 	}
+
 	if err = tcs.InputFields.IsValid(); err != nil {
 		return nil, err
 	}
@@ -138,6 +188,12 @@ func New(reader io.Reader) (*TestCaseSet, error) {
 			tcs.descriptions = append(tcs.descriptions, tc.Description)
 		}
 	}
+
+	// Convert dot fields
+	if err := tcs.convertDotFileds(); err != nil {
+		return nil, err
+	}
+
 	return &tcs, nil
 }
 
@@ -147,6 +203,8 @@ func NewFromFile(path string) (*TestCaseSet, error) {
 	if err != nil {
 		return nil, err
 	}
+	ext := strings.TrimPrefix(filepath.Ext(abspath), ".")
+	log.Debugf("File extension: %s", ext)
 
 	log.Debug("Reading test case file: %s (%s)", path, abspath)
 	f, err := os.Open(path)
@@ -157,7 +215,7 @@ func NewFromFile(path string) (*TestCaseSet, error) {
 		_ = f.Close()
 	}()
 
-	tcs, err := New(f)
+	tcs, err := New(f, ext)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading/unmarshalling %s: %s", path, err)
 	}
@@ -203,7 +261,10 @@ func (tcs *TestCaseSet) Compare(events []logstash.Event, quiet bool, diffCommand
 		}
 
 		for _, ignored := range tcs.IgnoredFields {
-			delete(actualEvent, ignored)
+			// Ignored fields can be in a sub object
+			fieldTree := strings.Split(ignored, ".")
+			actualEvent = removeFields(fieldTree, actualEvent)
+
 		}
 
 		// Create a directory structure for the JSON file being

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -150,11 +150,11 @@ func (t *TestCaseSet) convertDotFields() error {
 // TestCase. Defaults to a "line" codec and ignoring the @version
 // field. If the configuration being read lists additional fields to
 // ignore those will be ignored in addition to @version.
-// configType must be json or yaml.
+// configType must be json or yaml or yml.
 func New(reader io.Reader, configType string) (*TestCaseSet, error) {
 
-	if configType != "json" && configType != "yaml" {
-		return nil, errors.New("Config type must be json or yaml")
+	if configType != "json" && configType != "yaml" && configType != "yml" {
+		return nil, errors.New("Config type must be json or yaml or yml")
 	}
 
 	tcs := TestCaseSet{

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -270,11 +270,9 @@ func (tcs *TestCaseSet) Compare(events []logstash.Event, quiet bool, diffCommand
 			fmt.Printf("Comparing message %d of %d from %s%s...\n", i+1, len(events), filepath.Base(tcs.File), description)
 		}
 
+		// Ignored fields can be in a sub object
 		for _, ignored := range tcs.IgnoredFields {
-			// Ignored fields can be in a sub object
-			fieldTree := strings.Split(ignored, ".")
-			actualEvent = removeFields(fieldTree, actualEvent)
-
+			removeFields(ignored, actualEvent)
 		}
 
 		// Create a directory structure for the JSON file being

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -21,8 +21,8 @@ func TestNew(t *testing.T) {
 	}{
 		// Happy flow relying on the default codec.
 		{
-			`{"fields": {"type": "mytype"}}`,
-			TestCaseSet{
+			input: `{"fields": {"type": "mytype"}}`,
+			expected: TestCaseSet{
 				Codec: "line",
 				InputFields: logstash.FieldSet{
 					"type": "mytype",
@@ -32,8 +32,8 @@ func TestNew(t *testing.T) {
 		},
 		// Happy flow with a custom codec.
 		{
-			`{"fields": {"type": "mytype"}, "codec": "json_lines"}`,
-			TestCaseSet{
+			input: `{"fields": {"type": "mytype"}, "codec": "json_lines"}`,
+			expected: TestCaseSet{
 				Codec: "json_lines",
 				InputFields: logstash.FieldSet{
 					"type": "mytype",
@@ -43,11 +43,47 @@ func TestNew(t *testing.T) {
 		},
 		// Additional fields to ignore are appended to the default.
 		{
-			`{"ignore": ["foo"]}`,
-			TestCaseSet{
+			input: `{"ignore": ["foo"]}`,
+			expected: TestCaseSet{
 				Codec:         "line",
 				InputFields:   logstash.FieldSet{},
 				IgnoredFields: []string{"@version", "foo"},
+			},
+		},
+		// Fields with dot notation
+		{
+			input: `{"fields": {"type": "mytype", "log.file.path": "/tmp/file.log"}}`,
+			expected: TestCaseSet{
+				Codec: "line",
+				InputFields: logstash.FieldSet{
+					"type": "mytype",
+					"log": map[string]interface{}{
+						"file": map[string]interface{}{
+							"path": "/tmp/file.log",
+						},
+					},
+				},
+				IgnoredFields: []string{"@version"},
+			},
+		},
+		// No handle input with dot notation when codec is line
+		{
+			input: `{"input": ["{\"test.path\": \"test\"}"]}`,
+			expected: TestCaseSet{
+				Codec:         "line",
+				InputLines:    []string{"{\"test.path\": \"test\"}"},
+				IgnoredFields: []string{"@version"},
+				InputFields:   logstash.FieldSet{},
+			},
+		},
+		// handle input with dot notation when codec is json_lines
+		{
+			input: `{"input": ["{\"test.path\": \"test\"}"], "codec": "json_lines"}`,
+			expected: TestCaseSet{
+				Codec:         "json_lines",
+				InputLines:    []string{"{\"test\":{\"path\":\"test\"}}"},
+				IgnoredFields: []string{"@version"},
+				InputFields:   logstash.FieldSet{},
 			},
 		},
 	}
@@ -82,12 +118,28 @@ func TestNewFromFile(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
+	// Test with JSON file
 	fullTestCasePath := filepath.Join(tempdir, "test.json")
 	if err = ioutil.WriteFile(fullTestCasePath, []byte(`{"type": "test"}`), 0644); err != nil {
 		t.Fatalf(err.Error())
 	}
 
 	tcs, err := NewFromFile("test.json")
+	if err != nil {
+		t.Fatalf("NewFromFile() unexpectedly returned an error: %s", err)
+	}
+
+	if tcs.File != fullTestCasePath {
+		t.Fatalf("Expected test case path to be %q, got %q instead.", fullTestCasePath, tcs.File)
+	}
+
+	// Test with YAML file
+	fullTestCasePath = filepath.Join(tempdir, "test.yaml")
+	if err = ioutil.WriteFile(fullTestCasePath, []byte(`{"type": "test"}`), 0644); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	tcs, err = NewFromFile("test.yaml")
 	if err != nil {
 		t.Fatalf("NewFromFile() unexpectedly returned an error: %s", err)
 	}
@@ -280,6 +332,41 @@ func TestCompare(t *testing.T) {
 			[]logstash.Event{
 				{
 					"ignored":     "ignoreme",
+					"not_ignored": "value",
+				},
+			},
+			[]string{"diff"},
+			nil,
+		},
+		// Ignorded filed with dot notation are ignored
+		{
+			&TestCaseSet{
+				File: "/path/to/filename.json",
+				InputFields: logstash.FieldSet{
+					"type": "test",
+				},
+				Codec:         "line",
+				IgnoredFields: []string{"file.log.path"},
+				InputLines:    []string{},
+				ExpectedEvents: []logstash.Event{
+					{
+						"not_ignored": "value",
+						"file": map[string]interface{}{
+							"log": map[string]interface{}{
+								"line": "value",
+							},
+						},
+					},
+				},
+			},
+			[]logstash.Event{
+				{
+					"file": map[string]interface{}{
+						"log": map[string]interface{}{
+							"line": "value",
+							"path": "ignore_me",
+						},
+					},
 					"not_ignored": "value",
 				},
 			},

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -373,6 +373,35 @@ func TestCompare(t *testing.T) {
 			[]string{"diff"},
 			nil,
 		},
+		// Ignorded filed with dot notation are ignored (when empty hash)
+		{
+			&TestCaseSet{
+				File: "/path/to/filename.json",
+				InputFields: logstash.FieldSet{
+					"type": "test",
+				},
+				Codec:         "line",
+				IgnoredFields: []string{"file.log.path"},
+				InputLines:    []string{},
+				ExpectedEvents: []logstash.Event{
+					{
+						"not_ignored": "value",
+					},
+				},
+			},
+			[]logstash.Event{
+				{
+					"file": map[string]interface{}{
+						"log": map[string]interface{}{
+							"path": "ignore_me",
+						},
+					},
+					"not_ignored": "value",
+				},
+			},
+			[]string{"diff"},
+			nil,
+		},
 		// Diff command execution errors are propagated correctly.
 		{
 			&TestCaseSet{

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -147,6 +147,21 @@ func TestNewFromFile(t *testing.T) {
 	if tcs.File != fullTestCasePath {
 		t.Fatalf("Expected test case path to be %q, got %q instead.", fullTestCasePath, tcs.File)
 	}
+
+	// Test with YML file
+	fullTestCasePath = filepath.Join(tempdir, "test.yml")
+	if err = ioutil.WriteFile(fullTestCasePath, []byte(`{"type": "test"}`), 0644); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	tcs, err = NewFromFile("test.yml")
+	if err != nil {
+		t.Fatalf("NewFromFile() unexpectedly returned an error: %s", err)
+	}
+
+	if tcs.File != fullTestCasePath {
+		t.Fatalf("Expected test case path to be %q, got %q instead.", fullTestCasePath, tcs.File)
+	}
 }
 
 func TestCompare(t *testing.T) {

--- a/testcase/testcase_test.go
+++ b/testcase/testcase_test.go
@@ -52,7 +52,7 @@ func TestNew(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		tcs, err := New(bytes.NewReader([]byte(c.input)))
+		tcs, err := New(bytes.NewReader([]byte(c.input)), "json")
 		if err != nil {
 			t.Errorf("Test %d: %q input: %s", i, c.input, err)
 			break


### PR DESCRIPTION
Add some enhances:
- Add test case YAML support and keep JSON support
- Add dot notation in exclude fields to excludes sub fields like `log.file.path`
- Add dot notation in fields to write test in easy way: `"log.file.path": "/tmp/test.log"` is equivalent to `"log": {"file": {"path": "/tmp/test.log"}}`.
- Add dot notation in input when use `json_lines` codecs to write test in easy way: `{"log.file.path": "/tmp/test.log"}` is equivalent to `{"log": {"file": {"path": "/tmp/test.log"}}}`.

I add some unit test and fix readme.