### PR TITLE
Remove dot notation, support only bracket notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,21 +245,18 @@ may have the following properties:
   numbers, and booleans) are supported, as are objects (containing
   scalars, arrays and nested objects), arrays of scalars and nested arrays.
   The only combination which is not allowed are objects within arrays.
-  You can use the "dot" or bracket notation field to write test in easy way.
-  It means that `fields: {"log.file.path": "/tmp/test.log"}` is equivalent to
-  `fields: {"log": {"file": {"path": "/tmp/test.log"}}}`. You can also write
-  `fields: {"[log][file][path]": "/tmp/test.log"}` to do the same thing.
+  You can use the bracket notation field to write test in easy way.
+  It means that `fields: {"[log][file][path]": "/tmp/test.log"}` is equivalent to
+  `fields: {"log": {"file": {"path": "/tmp/test.log"}}}`.
 * `ignore`: An array with the names of the fields that should be
   removed from the events that Logstash emit. This is for example
   useful for dynamically generated fields whose contents can't be
   predicted and hardwired into the test case file. If you need to exclude
-  sub fields, you need to use dot or bracket notation, i.e. `log.file.path`
-  or `[log][file][path]` will exclude field
+  sub fields, you need to use bracket notation, i.e. `[log][file][path]` will exclude field
   `{"log": {"file": {"path": "something"}}}`.
 * `input`: An array with the lines of input (each line being a string)
   that should be fed to the Logstash process. If you use `json_lines` codec
-  you can use dot or bracket notation for fields, making
-  `{"message": "my message", "log.file.path": "/tmp/test.log"}` and
+  you can use bracket notation for fields, making
   `{"message": "my message", "[log][file][path]": "/tmp/test.log"}` equivalent
   to `{"message": "my message", "log": {"file": {"path": "/tmp/test.log"}}}`.
 * `testcases`: An array of test case hashes, consisting of a field `input`

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/axw/gocov v1.0.0
 	github.com/breml/logstash-config v0.1.0
 	github.com/go-playground/overalls v0.0.0-20180201144345-22ec1a223b7c
-	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/packer v1.4.4
 	github.com/matm/gocov-html v0.0.0-20191111163307-9ee104d84c82
 	github.com/mattn/go-shellwords v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/axw/gocov v1.0.0
 	github.com/breml/logstash-config v0.1.0
 	github.com/go-playground/overalls v0.0.0-20180201144345-22ec1a223b7c
+	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/packer v1.4.4
 	github.com/matm/gocov-html v0.0.0-20191111163307-9ee104d84c82
 	github.com/mattn/go-shellwords v1.0.6

--- a/testcase/helper_test.go
+++ b/testcase/helper_test.go
@@ -36,6 +36,8 @@ func TestExtractBracketFields(t *testing.T) {
 	expected = []string{
 		"[log]badformat",
 	}
+	result = extractBracketFields(key)
+	assert.Equal(t, expected, result)
 
 }
 

--- a/testcase/helper_test.go
+++ b/testcase/helper_test.go
@@ -6,31 +6,55 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestParseDotProperty test keys that contain dot or bracket notation are converted to sub structure
-func TestParseDotProperty(t *testing.T) {
+func TestExtractBracketFields(t *testing.T) {
 	var (
 		key      string
+		result   []string
+		expected []string
+	)
+
+	// When bracket
+	key = "[log][file][path]"
+	expected = []string{
+		"log",
+		"file",
+		"path",
+	}
+	result = extractBracketFields(key)
+	assert.Equal(t, expected, result)
+
+	// When no bracket
+	key = "message"
+	expected = []string{
+		"message",
+	}
+	result = extractBracketFields(key)
+	assert.Equal(t, expected, result)
+
+	// When bad bracket
+	key = "[log]badformat"
+	expected = []string{
+		"[log]badformat",
+	}
+
+}
+
+// TestParseBracketProperty test keys that contain bracket notation are converted to sub structure
+func TestParseBracketProperty(t *testing.T) {
+
+	var (
+		key      []string
 		value    string
 		result   map[string]interface{}
 		expected map[string]interface{}
 	)
 
-	// Create sub structure with dot notation
-	key = "log.file.path"
-	value = "/tmp/test.log"
-	result = make(map[string]interface{})
-	expected = map[string]interface{}{
-		"log": map[string]interface{}{
-			"file": map[string]interface{}{
-				"path": "/tmp/test.log",
-			},
-		},
-	}
-	parseDotProperty(key, value, result)
-	assert.Equal(t, expected, result)
-
 	// Create sub structure with bracket notation
-	key = "[log][file][path]"
+	key = []string{
+		"log",
+		"file",
+		"path",
+	}
 	value = "/tmp/test.log"
 	result = make(map[string]interface{})
 	expected = map[string]interface{}{
@@ -40,17 +64,17 @@ func TestParseDotProperty(t *testing.T) {
 			},
 		},
 	}
-	parseDotProperty(key, value, result)
+	parseBracketProperty(key, value, result)
 	assert.Equal(t, expected, result)
 
 	// Do nothing when no bracket and not dot
-	key = "message"
+	key = []string{"message"}
 	value = "/tmp/test.log"
 	result = make(map[string]interface{})
 	expected = map[string]interface{}{
 		"message": "/tmp/test.log",
 	}
-	parseDotProperty(key, value, result)
+	parseBracketProperty(key, value, result)
 	assert.Equal(t, expected, result)
 }
 
@@ -59,7 +83,7 @@ func TestParseDotProperty(t *testing.T) {
 func TestParseAllDotProperties(t *testing.T) {
 	data := map[string]interface{}{
 		"message":             "my message",
-		"log.file.path":       "/tmp/test.log",
+		"[log][file][path]":   "/tmp/test.log",
 		"[log][origin][line]": 2,
 	}
 	expected := map[string]interface{}{
@@ -74,12 +98,12 @@ func TestParseAllDotProperties(t *testing.T) {
 		},
 	}
 
-	result := parseAllDotProperties(data)
+	result := parseAllBracketProperties(data)
 	assert.Equal(t, expected, result)
 }
 
 // TestRemoveField tests that ignored fields are removed from actual events.
-// It supports dot and bracket notation.
+// It supports bracket notation.
 func TestRemoveField(t *testing.T) {
 	var (
 		keys     []string
@@ -163,7 +187,7 @@ func TestRemoveField(t *testing.T) {
 }
 
 // TestRemoveFields tests that ignored field are removed from actual events
-// It supports dot and bracket notation.
+// It supports bracket notation.
 func TestRemoveFields(t *testing.T) {
 	var (
 		key      string
@@ -189,24 +213,6 @@ func TestRemoveFields(t *testing.T) {
 			},
 		},
 		"source": "test",
-	}
-	removeFields(key, data)
-	assert.Equal(t, expected, data)
-
-	// Test when keys uses dot notation
-	data = map[string]interface{}{
-		"message": "my message",
-		"log": map[string]interface{}{
-			"file": map[string]interface{}{
-				"path": "/tmp/file.log",
-			},
-		},
-		"source": "test",
-	}
-	key = "log.file.path"
-	expected = map[string]interface{}{
-		"message": "my message",
-		"source":  "test",
 	}
 	removeFields(key, data)
 	assert.Equal(t, expected, data)

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -113,15 +113,15 @@ var (
 	defaultIgnoredFields = []string{"@version"}
 )
 
-// convertDotFields permit to replace keys that contains dot with sub structure.
-// For example, the key `log.file.path` will be convert by `"log": {"file": {"path": "VALUE"}}`
-func (tcs *TestCaseSet) convertDotFields() error {
+// convertBracketFields permit to replace keys that contains bracket with sub structure.
+// For example, the key `[log][file][path]` will be convert by `"log": {"file": {"path": "VALUE"}}`
+func (tcs *TestCaseSet) convertBracketFields() error {
 	// Convert fields in input fields
-	tcs.InputFields = parseAllDotProperties(tcs.InputFields)
+	tcs.InputFields = parseAllBracketProperties(tcs.InputFields)
 
 	// Convert fields in expected events
 	for i, expected := range tcs.ExpectedEvents {
-		tcs.ExpectedEvents[i] = parseAllDotProperties(expected)
+		tcs.ExpectedEvents[i] = parseAllBracketProperties(expected)
 	}
 
 	// Convert fields in input json string
@@ -131,7 +131,7 @@ func (tcs *TestCaseSet) convertDotFields() error {
 			if err := json.Unmarshal([]byte(line), &jsonObj); err != nil {
 				return err
 			}
-			jsonObj = parseAllDotProperties(jsonObj)
+			jsonObj = parseAllBracketProperties(jsonObj)
 			data, err := json.Marshal(jsonObj)
 			if err != nil {
 				return err
@@ -188,8 +188,8 @@ func New(reader io.Reader, configType string) (*TestCaseSet, error) {
 		}
 	}
 
-	// Convert dot fields
-	if err := tcs.convertDotFields(); err != nil {
+	// Convert bracket fields
+	if err := tcs.convertBracketFields(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Remove dot notation support and keep only bracket notation for inputs, excludes and fields