### PR TITLE
Insert codec as a string, not as a single-quoted character literal.

### DIFF
--- a/logstash/parallel_process.go
+++ b/logstash/parallel_process.go
@@ -168,7 +168,7 @@ func getSocketInOutPlugins(testStream []*TestStream) ([]string, []string, error)
 		if err != nil {
 			return nil, nil, err
 		}
-		logstashInput[i] = fmt.Sprintf("unix { mode => \"client\" path => %q codec => %q add_field => %s }",
+		logstashInput[i] = fmt.Sprintf("unix { mode => \"client\" path => %q codec => %s add_field => %s }",
 			sp.senderPath, sp.inputCodec, fieldHash)
 		logstashOutput[i] = fmt.Sprintf("if [@metadata][__lfv_testcase] == \"%s\" { file { path => %q codec => \"json_lines\" } }",
 			strconv.Itoa(i), sp.receiver.Name())

--- a/logstash/parallel_process_test.go
+++ b/logstash/parallel_process_test.go
@@ -97,7 +97,7 @@ func TestGetSocketInOutPlugins(t *testing.T) {
 				},
 			},
 			[]string{
-				"unix { mode => \"client\" path => \"/tmp/foo\" codec => \"any_codec\" " +
+				"unix { mode => \"client\" path => \"/tmp/foo\" codec => any_codec " +
 					"add_field => { \"[@metadata][__lfv_testcase]\" => \"0\" } }",
 			},
 			[]string{
@@ -122,9 +122,9 @@ func TestGetSocketInOutPlugins(t *testing.T) {
 				},
 			},
 			[]string{
-				"unix { mode => \"client\" path => \"/tmp/foo\" codec => \"any_codec\" " +
+				"unix { mode => \"client\" path => \"/tmp/foo\" codec => any_codec " +
 					"add_field => { \"[@metadata][__lfv_testcase]\" => \"0\" } }",
-				"unix { mode => \"client\" path => \"/tmp/bar\" codec => \"other_codec\" " +
+				"unix { mode => \"client\" path => \"/tmp/bar\" codec => other_codec " +
 					"add_field => { \"[@metadata][__lfv_testcase]\" => \"1\" } }",
 			},
 			[]string{
@@ -148,7 +148,7 @@ func TestGetSocketInOutPlugins(t *testing.T) {
 				},
 			},
 			[]string{
-				"unix { mode => \"client\" path => \"/tmp/foo\" codec => \"any_codec\" " +
+				"unix { mode => \"client\" path => \"/tmp/foo\" codec => any_codec " +
 					"add_field => { \"[@metadata][__lfv_testcase]\" => \"0\" \"[@metadata][foo]\" => \"bar\" } }",
 			},
 			[]string{

--- a/logstash/process.go
+++ b/logstash/process.go
@@ -51,7 +51,7 @@ func NewProcess(inv *Invocation, inputCodec string, fields FieldSet, keptEnvVars
 		_ = outputFile.Close()
 		return nil, err
 	}
-	inputs := fmt.Sprintf("input { stdin { codec => %q add_field => %s } }", inputCodec, fieldHash)
+	inputs := fmt.Sprintf("input { stdin { codec => %s add_field => %s } }", inputCodec, fieldHash)
 	outputs := fmt.Sprintf("output { file { path => %q codec => \"json_lines\" } }", outputFile.Name())
 
 	env := getLimitedEnvironment(os.Environ(), keptEnvVars)


### PR DESCRIPTION
This enables codecs that need additional configuration settings, like
`multiline` with an escaped string:

```
codec: "multiline {
       pattern => \"^%{YEAR}/%{MONTHNUM}/%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}:?%{SECOND}\"
       negate => true
       what => previous
    }"
```