### PR TITLE
README.md: quote @timestamp in yaml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ testcases:
           "time": "2015-10-06T20:55:29Z"
         }
     expected:
-      - @timestamp: "2015-10-06T20:55:29.000Z"
+      - "@timestamp": "2015-10-06T20:55:29.000Z"
         client: "localhost"
         clientip: "127.0.0.1"
         message: "This is a test message"


### PR DESCRIPTION
Using the example file leads to an error otherwise:

```
Error reading/unmarshalling testcases.yml: yaml: line 15: found character that cannot start any token
```