### PR TITLE
Small fixes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -25,7 +26,10 @@ func Execute(version string, stdout, stderr io.Writer) int {
 	// Initialize config
 	viper.SetConfigName("logstash-filter-verifier") // name of config file (without extension)
 	viper.AddConfigPath(".")
-	viper.AddConfigPath("$HOME/.logstash-filter-verifier")
+	configDir, err := os.UserConfigDir()
+	if err == nil {
+		viper.AddConfigPath(path.Join(configDir, "logstash-filter-verifier"))
+	}
 	viper.AddConfigPath("/etc/logstash-filter-verifier/")
 
 	// Setup default values

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -48,7 +48,7 @@ func Execute(version string, stdout, stderr io.Writer) int {
 	rootCmd.SilenceUsage = true
 
 	if err := rootCmd.Execute(); err != nil {
-		prefixedUserError("error: %v", err)
+		prefixedUserError(stderr, "error: %v", err)
 		return exitCodeError
 	}
 
@@ -81,12 +81,12 @@ func makeRootCmd(version string) *cobra.Command {
 // prefixedUserError prints an error message to stderr and prefixes it
 // with the name of the program file (e.g. "logstash-filter-verifier:
 // something bad happened.").
-func prefixedUserError(format string, a ...interface{}) {
+func prefixedUserError(out io.Writer, format string, a ...interface{}) {
 	basename := filepath.Base(os.Args[0])
 	message := fmt.Sprintf(format, a...)
 	if strings.HasSuffix(message, "\n") {
-		fmt.Fprintf(os.Stderr, "%s: %s", basename, message)
+		fmt.Fprintf(out, "%s: %s", basename, message)
 	} else {
-		fmt.Fprintf(os.Stderr, "%s: %s\n", basename, message)
+		fmt.Fprintf(out, "%s: %s\n", basename, message)
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,10 +23,10 @@ func Execute(version string, stdout, stderr io.Writer) int {
 	viper.Set("logger", log)
 
 	// Initialize config
-	viper.SetConfigName("logstash-filter-verifier")        // name of config file (without extension)
-	viper.AddConfigPath("/etc/logstash-filter-verifier/")  // path to look for the config file in
-	viper.AddConfigPath("$HOME/.logstash-filter-verifier") // call multiple times to add many search paths
-	viper.AddConfigPath(".")                               // optionally look for config in the working directory
+	viper.SetConfigName("logstash-filter-verifier") // name of config file (without extension)
+	viper.AddConfigPath(".")
+	viper.AddConfigPath("$HOME/.logstash-filter-verifier")
+	viper.AddConfigPath("/etc/logstash-filter-verifier/")
 
 	// Setup default values
 	viper.SetDefault("loglevel", "WARNING")

--- a/internal/app/standalone.go
+++ b/internal/app/standalone.go
@@ -89,7 +89,7 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		_, err := os.Stat(arg)
 		if os.IsNotExist(err) {
-			return fmt.Errorf("path '%s' does not exist, try --help", arg)
+			return fmt.Errorf("path %q does not exist, try --help", arg)
 		}
 	}
 	return nil


### PR DESCRIPTION
@magnusbaeck I am not sure, if `$HOME/.logstash-filter-verifier` is a good choice for the config file. I took this from the [examples of spf13/viper](https://pkg.go.dev/github.com/spf13/viper#readme-reading-config-files). Personally I think it would be better to use the directory from [os.UserConfigDir](https://golang.org/pkg/os/#UserConfigDir) and add the application name to it, like this:

```Go
configDir, err := os.UserHomeDir()
if err == nil {
	viper.AddConfigPath(path.Join(configDir, "logstash-filter-verifier"))
}
```

What do you think?