### PR TITLE
Add filter mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ahmetb/govvv v0.3.0
 	github.com/axw/gocov v1.0.0
 	github.com/bmatcuk/doublestar/v2 v2.0.4
-	github.com/breml/logstash-config v0.4.4
+	github.com/breml/logstash-config v0.4.5
 	github.com/go-playground/overalls v0.0.0-20191218162659-7df9f728c018
 	github.com/hashicorp/packer v1.4.4
 	github.com/hpcloud/tail v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/biogo/hts v0.0.0-20160420073057-50da7d4131a3/go.mod h1:YOY5xnRf7Jz2SZ
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmatcuk/doublestar/v2 v2.0.4 h1:6I6oUiT/sU27eE2OFcWqBhL1SwjyvQuOssxT4a1yidI=
 github.com/bmatcuk/doublestar/v2 v2.0.4/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
-github.com/breml/logstash-config v0.4.4 h1:JpRTXVnbZ19nBTf7hIfYzgSSyc2+mpdmdlj9Jt4UfU8=
-github.com/breml/logstash-config v0.4.4/go.mod h1:NaBkWLM71LaEUF/VoCAHMcQf0nAnOcPaaiRKKoRgPN0=
+github.com/breml/logstash-config v0.4.5 h1:12WtKpvkNQTOnyssgKxPLCYP9ZOA826d6hoDUeUcAqk=
+github.com/breml/logstash-config v0.4.5/go.mod h1:NaBkWLM71LaEUF/VoCAHMcQf0nAnOcPaaiRKKoRgPN0=
 github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/integration_test.go
+++ b/integration_test.go
@@ -113,6 +113,8 @@ func TestIntegration(t *testing.T) {
 		// optional integration tests require additional logstash plugins,
 		// which are not provided by a default installation.
 		optional bool
+
+		filterMock string
 	}{
 		{
 			name: "basic_pipeline",
@@ -133,6 +135,11 @@ func TestIntegration(t *testing.T) {
 		{
 			name:     "codec_optional_test",
 			optional: true,
+		},
+		{
+			name: "filtermock",
+
+			filterMock: "testdata/mocks/filtermock.yml",
 		},
 		{
 			name: "special_chars",
@@ -156,6 +163,7 @@ func TestIntegration(t *testing.T) {
 				"testdata/"+tc.name+".yml",
 				"testdata/"+tc.name,
 				"testdata/testcases/"+tc.name,
+				tc.filterMock,
 				"@metadata",
 				tc.debug,
 			)

--- a/internal/app/daemon_run.go
+++ b/internal/app/daemon_run.go
@@ -21,6 +21,8 @@ func makeDaemonRunCmd() *cobra.Command {
 	_ = viper.BindPFlag("pipeline-base", cmd.Flags().Lookup("pipeline-base"))
 	cmd.Flags().StringP("testcase-dir", "t", "", "directory containing the test case files")
 	_ = viper.BindPFlag("testcase-dir", cmd.Flags().Lookup("testcase-dir"))
+	cmd.Flags().String("filter-mock", "", "path to a yaml file containing the definition for the filter mocks.")
+	_ = viper.BindPFlag("filter-mock", cmd.Flags().Lookup("filter-mock"))
 	cmd.Flags().Bool("debug", false, "enable debug mode; e.g. prevents stripping '__lfv' data from Logstash events")
 	_ = viper.BindPFlag("debug", cmd.Flags().Lookup("debug"))
 	cmd.Flags().String("metadata-key", "@metadata", "Key under which the content of the `@metadata` field is exposed in the returned events.")
@@ -35,10 +37,11 @@ func runDaemonRun(_ *cobra.Command, args []string) error {
 	pipeline := viper.GetString("pipeline")
 	pipelineBase := viper.GetString("pipeline-base")
 	testcaseDir := viper.GetString("testcase-dir")
+	filterMock := viper.GetString("filter-mock")
 	debug := viper.GetBool("debug")
 	metadataKey := viper.GetString("metadata-key")
 
-	t, err := run.New(socket, log, pipeline, pipelineBase, testcaseDir, metadataKey, debug)
+	t, err := run.New(socket, log, pipeline, pipelineBase, testcaseDir, filterMock, metadataKey, debug)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/filtermock/filtermock.go
+++ b/internal/daemon/filtermock/filtermock.go
@@ -1,0 +1,100 @@
+// Filter mocks allow to replace an existing filter, identified by its ID, in
+// the config with a mock implementation.
+// This comes in handy, if a filter does perform a call out to an external
+// system e.g. lookup in Elasticsearch.
+// Because the existing filter is replaced with whatever is present in
+// `filter`, it is also possible to remove a filter by simple keep the
+// `filter` empty (or not present).
+package filtermock
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	config "github.com/breml/logstash-config"
+	"github.com/breml/logstash-config/ast"
+	"github.com/breml/logstash-config/ast/astutil"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+type Mock struct {
+	// ID of the Logstash filter to be mocked.
+	ID string `json:"id" yaml:"id"`
+
+	// Logstash configuration snippet of the replacement filter. E.g.
+	//
+	//     # Constant lookup, does return the same result for each event
+	//     mutate {
+	//       replace => {
+	//         "[field]" => "value"
+	//       }
+	//     }
+	Filter string `json:"filter,omitempty" yaml:"filter,omitempty"`
+}
+
+func FromFile(filename string) (Mocks, error) {
+	if filename == "" {
+		return Mocks{}, nil
+	}
+
+	mocks := []Mock{}
+
+	body, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return Mocks{}, err
+	}
+
+	err = yaml.Unmarshal(body, &mocks)
+	if err != nil {
+		return Mocks{}, err
+	}
+
+	filtermocks := make(Mocks, len(mocks))
+
+	for _, m := range mocks {
+		if m.Filter == "" {
+			filtermocks[m.ID] = nil
+			continue
+		}
+
+		wrappedFilter := []byte(fmt.Sprintf("filter {\n%s\n}", m.Filter))
+		cfg, err := config.Parse("", wrappedFilter)
+		if err != nil {
+			return Mocks{}, err
+		}
+
+		var filter ast.Plugin
+		var recoverErr interface{}
+
+		func() {
+			defer func() {
+				recoverErr = recover()
+			}()
+			filter = cfg.(ast.Config).Filter[0].BranchOrPlugins[0].(ast.Plugin)
+		}()
+
+		if recoverErr != nil {
+			return Mocks{}, errors.Errorf("failed to parse mock filter: %s", m.Filter)
+		}
+
+		filtermocks[m.ID] = &filter
+	}
+
+	return filtermocks, nil
+}
+
+type Mocks map[string]*ast.Plugin
+
+func (m Mocks) Walk(c *astutil.Cursor) {
+	id, _ := c.Plugin().ID()
+
+	if replacement, ok := m[id]; ok {
+		if replacement == nil {
+			c.Delete()
+			return
+		}
+		replacement.Attributes = append(replacement.Attributes, ast.NewStringAttribute("id", id, ast.Bareword))
+		c.Replace(replacement)
+	}
+}

--- a/internal/daemon/logstashconfig/file.go
+++ b/internal/daemon/logstashconfig/file.go
@@ -12,6 +12,7 @@ import (
 	"github.com/breml/logstash-config/ast/astutil"
 	"github.com/pkg/errors"
 
+	"github.com/magnusbaeck/logstash-filter-verifier/v2/internal/daemon/filtermock"
 	"github.com/magnusbaeck/logstash-filter-verifier/v2/internal/daemon/idgen"
 )
 
@@ -188,4 +189,19 @@ func (v *validator) walk(c *astutil.Cursor) {
 	if v.pluginType == ast.Output && c.Plugin().Name() != "pipeline" {
 		v.outputs++
 	}
+}
+
+func (f *File) ApplyMocks(m filtermock.Mocks) error {
+	err := f.parse()
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(f.config.Filter); i++ {
+		f.config.Filter[i].BranchOrPlugins = astutil.ApplyPlugins(f.config.Filter[i].BranchOrPlugins, m.Walk)
+	}
+
+	f.Body = []byte(f.config.String())
+
+	return nil
 }

--- a/internal/daemon/pipeline/pipeline_test.go
+++ b/internal/daemon/pipeline/pipeline_test.go
@@ -161,7 +161,7 @@ func TestZip(t *testing.T) {
 				return
 			}
 
-			b, err := a.Zip()
+			b, err := a.ZipWithPreprocessor(pipeline.NoopPreprocessor)
 			is.True(err != nil == test.wantZipBytesErr) // Zip error
 
 			if test.wantZipBytesErr {

--- a/testdata/filtermock.yml
+++ b/testdata/filtermock.yml
@@ -1,0 +1,2 @@
+- pipeline.id: main
+  path.config: "*.conf"

--- a/testdata/filtermock/filtermock.conf
+++ b/testdata/filtermock/filtermock.conf
@@ -1,0 +1,34 @@
+input {
+  stdin {
+    id => "stdin"
+  }
+}
+
+filter {
+  mutate {
+    id => "removeme"
+    add_field => {
+      "removeme" => "should not be present in output"
+    }
+  }
+
+  mutate {
+    id => "mockme"
+    replace => {
+      "[message]" => "not mocket"
+    }
+  }
+
+  mutate {
+    id => "keepme"
+    add_field => {
+      "keepme" => "visible in output"
+    }
+  }
+}
+
+output {
+  stdout {
+    id => "stdout"
+  }
+}

--- a/testdata/mocks/filtermock.yml
+++ b/testdata/mocks/filtermock.yml
@@ -1,0 +1,10 @@
+---
+
+- id: removeme
+- id: mockme
+  filter: |
+    mutate {
+      replace => {
+        "[message]" => "mocked"
+      }
+    }

--- a/testdata/testcases/filtermock/filtermock.json
+++ b/testdata/testcases/filtermock/filtermock.json
@@ -1,0 +1,19 @@
+{
+  "ignore": [
+    "@timestamp"
+  ],
+  "input_plugin": "stdin",
+  "testcases": [
+    {
+      "input": [
+        "input"
+      ],
+      "expected": [
+        {
+          "message": "mocked",
+          "keepme": "visible in output"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Implementation of the filter mock feature. In contrast to the proposal in https://github.com/magnusbaeck/logstash-filter-verifier/issues/94#issuecomment-770877220 it was not possible to add the definition for the filter mocks into the test case file, because the mocks are needed to be applied to the "initial" config, which is loaded in the setup phase. Therefore I decided to put the mock filters into their own yaml config file, which can be specified optionally via command line flag.

Please merge #109 first.