### PR TITLE
Fix multiple outputs from different pipelines

### DIFF
--- a/internal/app/daemon/run/run.go
+++ b/internal/app/daemon/run/run.go
@@ -3,7 +3,6 @@ package run
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"os"
 	"path"
@@ -145,12 +144,10 @@ func (s Test) Run() error {
 			return err
 		}
 
-		results, seenOutputs, err := s.postProcessResults(result.Results, t)
+		results, err := s.postProcessResults(result.Results, t)
 		if err != nil {
 			return err
 		}
-
-		verifySeenOutputs(t, seenOutputs, liveObserver)
 
 		var events []logstash.Event
 		for _, line := range results {
@@ -205,33 +202,19 @@ func (s Test) validateInputLines(lines []string) {
 	}
 }
 
-func (s Test) postProcessResults(results []string, t testcase.TestCaseSet) ([]string, map[int][]string, error) {
+func (s Test) postProcessResults(results []string, t testcase.TestCaseSet) ([]string, error) {
 	var err error
 
 	sort.Slice(results, func(i, j int) bool {
-		return gjson.Get(results[i], `__lfv_id`).Int() < gjson.Get(results[j], `__lfv_id`).Int()
+		idI := gjson.Get(results[i], `__lfv_id`).Int()
+		idJ := gjson.Get(results[j], `__lfv_id`).Int()
+		if idI == idJ {
+			return gjson.Get(results[i], `__lfv_out_passed`).String() < gjson.Get(results[j], `__lfv_out_passed`).String()
+		}
+		return idI < idJ
 	})
 
-	lastID := "n/a"
-	testcase := -1
-	seenOutputs := make(map[int][]string, len(results))
 	for i := 0; i < len(results); i++ {
-		// Collect expected outputs
-		id := gjson.Get(results[i], "__lfv_id").String()
-		if id != lastID {
-			testcase++
-		}
-
-		seenOutputs[testcase] = append(seenOutputs[testcase], gjson.Get(results[i], "__lfv_metadata.__lfv_out_passed").String())
-
-		if id == lastID {
-			// Remove duplicate event, processed by different output
-			results = append(results[:i], results[i+1:]...)
-			i--
-			continue
-		}
-		lastID = id
-
 		// Export metadata
 		if t.ExportMetadata {
 			metadata := gjson.Get(results[i], "__lfv_metadata")
@@ -246,14 +229,14 @@ func (s Test) postProcessResults(results []string, t testcase.TestCaseSet) ([]st
 				if len(md) > 0 {
 					results[i], err = sjson.Set(results[i], s.metadataKey, md)
 					if err != nil {
-						return nil, nil, err
+						return nil, err
 					}
 				}
 			}
 		}
 		results[i], err = sjson.Delete(results[i], "__lfv_metadata")
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		// No cleanup if debug is set
@@ -263,7 +246,14 @@ func (s Test) postProcessResults(results []string, t testcase.TestCaseSet) ([]st
 
 		results[i], err = sjson.Delete(results[i], "__lfv_id")
 		if err != nil {
-			return nil, nil, err
+			return nil, err
+		}
+
+		if !t.ExportOutputs {
+			results[i], err = sjson.Delete(results[i], "__lfv_out_passed")
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		tags := []string{}
@@ -281,46 +271,9 @@ func (s Test) postProcessResults(results []string, t testcase.TestCaseSet) ([]st
 			results[i], err = sjson.Set(results[i], "tags", tags)
 		}
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return results, seenOutputs, nil
-}
-
-func verifySeenOutputs(tcs testcase.TestCaseSet, seenOutputs map[int][]string, liveObserver observer.Property) {
-	for i := 0; i < len(tcs.TestCases); i++ {
-		if len(tcs.TestCases[i].ExpectedOutputs) == 0 {
-			continue
-		}
-
-		sort.Strings(tcs.TestCases[i].ExpectedOutputs)
-		sort.Strings(seenOutputs[i])
-
-		comparisonResult := lfvobserver.ComparisonResult{
-			Status:     true,
-			Name:       fmt.Sprintf("Comparing Logstash outputs of message %d of %d", i+1, len(tcs.TestCases)),
-			Path:       filepath.Base(tcs.File),
-			EventIndex: i,
-		}
-
-		if !equal(tcs.TestCases[i].ExpectedOutputs, seenOutputs[i]) {
-			comparisonResult.Status = false
-			comparisonResult.Explain = fmt.Sprintf("Expected Logstash outputs: %v\nActually seen Logstash outputs: %v", tcs.TestCases[i].ExpectedOutputs, seenOutputs[i])
-		}
-
-		liveObserver.Update(comparisonResult)
-	}
-}
-
-func equal(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
+	return results, nil
 }

--- a/internal/daemon/controller/controller.go
+++ b/internal/daemon/controller/controller.go
@@ -130,6 +130,9 @@ func (c *Controller) ExecuteTest(pipelines pipeline.Pipelines, expectedEvents in
 }
 
 func (c *Controller) GetResults() ([]string, error) {
+	// Check if complete right away for the special case, where no event is expected.
+	c.checkComplete()
+
 	err := c.stateMachine.waitForState(stateReadyForTest)
 	if err != nil {
 		return nil, err
@@ -197,6 +200,10 @@ func (c *Controller) writePipelines(pipelines ...pipeline.Pipeline) error {
 func (c *Controller) ReceiveEvent(event string) {
 	c.receivedEvents.append(event)
 
+	c.checkComplete()
+}
+
+func (c *Controller) checkComplete() {
 	if c.receivedEvents.isCompleteFirstTime() {
 		go func() {
 			_ = c.stateMachine.waitForState(stateRunningTest)

--- a/internal/daemon/controller/events.go
+++ b/internal/daemon/controller/events.go
@@ -2,13 +2,10 @@ package controller
 
 import (
 	"sync"
-
-	"github.com/tidwall/gjson"
 )
 
 type events struct {
 	events            []string
-	receivedUniqueIDs map[string]struct{}
 	completeFirstTime bool
 	expected          int
 	mutex             *sync.Mutex
@@ -16,9 +13,8 @@ type events struct {
 
 func newEvents() *events {
 	return &events{
-		events:            make([]string, 0, 100),
-		receivedUniqueIDs: make(map[string]struct{}, 100),
-		mutex:             &sync.Mutex{},
+		events: make([]string, 0, 100),
+		mutex:  &sync.Mutex{},
 	}
 }
 
@@ -27,15 +23,13 @@ func (e *events) append(event string) {
 	defer e.mutex.Unlock()
 
 	e.events = append(e.events, event)
-	id := gjson.Get(event, `__lfv_id`).String()
-	e.receivedUniqueIDs[id] = struct{}{}
 }
 
 func (e *events) isCompleteFirstTime() bool {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	if e.expected == len(e.receivedUniqueIDs) && !e.completeFirstTime {
+	if e.expected == len(e.events) && !e.completeFirstTime {
 		e.completeFirstTime = true
 		return true
 	}
@@ -49,7 +43,6 @@ func (e *events) reset(expected int) {
 
 	e.expected = expected
 	e.events = make([]string, 0, 100)
-	e.receivedUniqueIDs = make(map[string]struct{}, 100)
 	e.completeFirstTime = false
 }
 

--- a/internal/daemon/session/files.go
+++ b/internal/daemon/session/files.go
@@ -9,7 +9,7 @@ const outputPipeline = `input {
 filter {
   mutate {
     add_tag => [ "__lfv_out_{{ .PipelineOrigName }}_passed" ]
-    add_field => { "[@metadata][__lfv_out_passed]" => "{{ .PipelineOrigName }}" }
+    add_field => { "[__lfv_out_passed]" => "{{ .PipelineOrigName }}" }
   }
 }
 

--- a/internal/testcase/testcase.go
+++ b/internal/testcase/testcase.go
@@ -82,6 +82,12 @@ type TestCaseSet struct {
 	// with the expected result of the testcase as well. (default: false)
 	ExportMetadata bool `json:"export_metadata" yaml:"export_metadata"`
 
+	// ExportOutputs controls if the ID of the output, a particular event has
+	// emitted by, is kept in the event or not.
+	// If this is enabled, the expected event needs to contain a field named
+	// __lfv_out_passed which contains the the ID of the Logstash output.
+	ExportOutputs bool `json:"export_outputs" yaml:"export_outputs"`
+
 	// TestCases is a slice of test cases, which include at minimum
 	// a pair of an input and an expected event
 	// Optionally other information regarding the test case
@@ -112,17 +118,6 @@ type TestCase struct {
 	// compared to the actual events produced by the Logstash
 	// process.
 	ExpectedEvents []logstash.Event `json:"expected" yaml:"expected"`
-
-	// The unique ID of the output plugins in the tested configuration, where
-	// the event leaves Logstash. (optional)
-	// If no value is present or the list is empty, this criteria is not verified.
-	// If a value is present, the event is expected to be processed by
-	// the exact list of expected outputs.
-	// By listing multiple output plugins it is possible to test Logstash
-	// configurations with multiple (conditional) outputs:
-	// e.g. save the events to elasticsearch and, if the threshold is above x,
-	// additionally send an email.
-	ExpectedOutputs []string `json:"expected_outputs" yaml:"expected_outputs"`
 
 	// Description contains an optional description of the test case
 	// which will be printed while the tests are executed.

--- a/internal/testcase/testcase.go
+++ b/internal/testcase/testcase.go
@@ -76,7 +76,7 @@ type TestCaseSet struct {
 	ExpectedEvents []logstash.Event `json:"expected" yaml:"expected"`
 
 	// ExportMetadata controls if the metadata of the event processed
-	// by Logstash is returned The metadata is contained in the field
+	// by Logstash is returned. The metadata is contained in the field
 	// `[@metadata]` in the Logstash event.
 	// If the metadata is exported, the respective fields are compared
 	// with the expected result of the testcase as well. (default: false)

--- a/testdata/multiple_parallel_outputs/stage1.conf
+++ b/testdata/multiple_parallel_outputs/stage1.conf
@@ -4,6 +4,13 @@ input {
   }
 }
 
+filter {
+  mutate {
+    id => "stage1_mutate"
+    add_tag => [ "stage1" ]
+  }
+}
+
 output {
   stdout {
     id => "stage1_stdout"

--- a/testdata/multiple_parallel_outputs/stage2.conf
+++ b/testdata/multiple_parallel_outputs/stage2.conf
@@ -5,6 +5,13 @@ input {
   }
 }
 
+filter {
+  mutate {
+    id => "stage2_mutate"
+    add_tag => [ "stage2" ]
+  }
+}
+
 output {
   file {
     id => "stage2_file"

--- a/testdata/testcases/basic_pipeline_debug/testcase1.json
+++ b/testdata/testcases/basic_pipeline_debug/testcase1.json
@@ -15,6 +15,7 @@
       "expected": [
         {
           "__lfv_id": "0",
+          "__lfv_out_passed": "stdout",
           "message": "test case message",
           "tags": [
             "__lfv_in_passed",
@@ -26,6 +27,7 @@
         },
         {
           "__lfv_id": "1",
+          "__lfv_out_passed": "stdout",
           "message": "test case message 2",
           "tags": [
             "__lfv_in_passed",

--- a/testdata/testcases/basic_pipeline_debug/testcase2.json
+++ b/testdata/testcases/basic_pipeline_debug/testcase2.json
@@ -19,6 +19,7 @@
             "hidden_field": "hidden value"
           },
           "__lfv_id": "0",
+          "__lfv_out_passed": "stdout",
           "first": "1",
           "message": "",
           "second": "2",

--- a/testdata/testcases/drop_and_split/drop_all.json
+++ b/testdata/testcases/drop_and_split/drop_all.json
@@ -1,0 +1,17 @@
+{
+  "fields": {
+  },
+  "ignore": [
+    "@timestamp"
+  ],
+  "input_plugin": "stdin",
+  "testcases": [
+    {
+      "input": [
+        "drop this input",
+        "drop this input"
+      ],
+      "expected": []
+    }
+  ]
+}

--- a/testdata/testcases/multiple_parallel_outputs/multiple_parallel_outputs_export_outputs.json
+++ b/testdata/testcases/multiple_parallel_outputs/multiple_parallel_outputs_export_outputs.json
@@ -1,3 +1,4 @@
+
 {
   "fields": {
   },
@@ -5,6 +6,7 @@
     "@timestamp"
   ],
   "input_plugin": "stdin",
+  "export_outputs": true,
   "testcases": [
     {
       "input": [
@@ -12,6 +14,7 @@
       ],
       "expected": [
         {
+          "__lfv_out_passed": "stage1_stdout",
           "message": "one output",
           "tags": [ "stage1" ]
         }
@@ -23,10 +26,12 @@
       ],
       "expected": [
         {
+          "__lfv_out_passed": "stage1_file",
           "message": "multiple outputs",
           "tags": [ "stage1" ]
         },
         {
+          "__lfv_out_passed": "stage1_stdout",
           "message": "multiple outputs",
           "tags": [ "stage1" ]
         }
@@ -38,10 +43,12 @@
       ],
       "expected": [
         {
+          "__lfv_out_passed": "stage1_stdout",
           "message": "stage2",
           "tags": [ "stage1" ]
         },
         {
+          "__lfv_out_passed": "stage2_file",
           "message": "stage2",
           "tags": [ "stage1", "stage2" ]
         }
@@ -53,14 +60,17 @@
       ],
       "expected": [
         {
+          "__lfv_out_passed": "stage1_file",
           "message": "multiple outputs and stage2",
           "tags": [ "stage1" ]
         },
         {
+          "__lfv_out_passed": "stage1_stdout",
           "message": "multiple outputs and stage2",
           "tags": [ "stage1" ]
         },
         {
+          "__lfv_out_passed": "stage2_file",
           "message": "multiple outputs and stage2",
           "tags": [ "stage1", "stage2" ]
         }


### PR DESCRIPTION
The goal of the `ExpectedOutputs` configuration has been to support cases, where an event is processed by multiple outputs. If these outputs are not located in the same pipeline, chances are, that the resulting events is do not look the same in both outputs. Therefore, the old approach with a simple list of outputs does fall short.

With the new approach, an the test case needs to contain an expected event for each output. In order to maintain reproducible, the received events are sorted by `__lfv_id` and by `__lfv_out_passed`.

For an example have a look at the "multiple_parallel_outputs" integration test.