### PR TITLE
Fix input codec and default value for --pipeline flag

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -35,7 +35,6 @@ func Execute(version string, stdout, stderr io.Writer) int {
 	// Setup default values
 	viper.SetDefault("loglevel", "WARNING")
 	viper.SetDefault("socket", "/tmp/logstash-filter-verifier.sock")
-	viper.SetDefault("pipeline", "/etc/logstash/pipelines.yml")
 	viper.SetDefault("logstash.path", "/usr/share/logstash/bin/logstash")
 	viper.SetDefault("inflight-shutdown-timeout", 10*time.Second)
 	viper.SetDefault("shutdown-timeout", 3*time.Second)

--- a/internal/app/daemon_run.go
+++ b/internal/app/daemon_run.go
@@ -16,7 +16,7 @@ func makeDaemonRunCmd() *cobra.Command {
 		RunE:  runDaemonRun,
 	}
 
-	cmd.Flags().StringP("pipeline", "p", "", "location of the pipelines.yml file to be processed")
+	cmd.Flags().StringP("pipeline", "p", "", "location of the pipelines.yml file to be processed (e.g. /etc/logstash/pipelines.yml)")
 	_ = viper.BindPFlag("pipeline", cmd.Flags().Lookup("pipeline"))
 	cmd.Flags().String("pipeline-base", "", "base directory for relative paths in the pipelines.yml")
 	_ = viper.BindPFlag("pipeline-base", cmd.Flags().Lookup("pipeline-base"))

--- a/internal/daemon/session/session.go
+++ b/internal/daemon/session/session.go
@@ -87,7 +87,9 @@ func (s *Session) setupTest(pipelines pipeline.Pipelines, configFiles []logstash
 		if err != nil {
 			return err
 		}
-		s.inputPluginCodecs = inputCodecs
+		for id, codec := range inputCodecs {
+			s.inputPluginCodecs[id] = codec
+		}
 
 		outputs, err := configFile.ReplaceOutputs()
 		if err != nil {


### PR DESCRIPTION
* Fix handling of input codecs for cases, where multiple files contain input plugins
* Remove default value for --pipeline flag