### PR TITLE
Fix how pipeline base path is determined

### DIFF
--- a/internal/app/daemon/run/run.go
+++ b/internal/app/daemon/run/run.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -45,7 +44,14 @@ type Test struct {
 }
 
 func New(socket string, log logging.Logger, pipeline, pipelineBase, logstashConfig, testcasePath, filterMock, metadataKey string, debug, addMissingID bool) (Test, error) {
-	if !path.IsAbs(pipelineBase) {
+	if pipelineBase == "" {
+		absPipeline, err := filepath.Abs(pipeline)
+		if err != nil {
+			return Test{}, err
+		}
+		pipelineBase = filepath.Dir(absPipeline)
+	}
+	if !filepath.IsAbs(pipelineBase) {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return Test{}, err

--- a/internal/daemon/pipeline/pipeline.go
+++ b/internal/daemon/pipeline/pipeline.go
@@ -77,7 +77,11 @@ func processNestedKeys(pipelines Pipelines) {
 func (a Archive) Validate(addMissingID bool) error {
 	var inputs, outputs int
 	for _, pipeline := range a.Pipelines {
-		files, err := doublestar.Glob(filepath.Join(a.BasePath, pipeline.Config))
+		configFilepath := filepath.Join(a.BasePath, pipeline.Config)
+		if filepath.IsAbs(pipeline.Config) {
+			configFilepath = pipeline.Config
+		}
+		files, err := doublestar.Glob(configFilepath)
 		if err != nil {
 			return err
 		}
@@ -137,7 +141,11 @@ func (a Archive) ZipWithPreprocessor(preprocess func([]byte) ([]byte, error)) ([
 	}
 
 	for _, pipeline := range a.Pipelines {
-		files, err := doublestar.Glob(filepath.Join(a.BasePath, pipeline.Config))
+		configFilepath := filepath.Join(a.BasePath, pipeline.Config)
+		if filepath.IsAbs(pipeline.Config) {
+			configFilepath = pipeline.Config
+		}
+		files, err := doublestar.Glob(configFilepath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* default value for --pipeline-base stays "" (empty string)
* if the config paths found in the pipelines.yml are absolute paths,
  the pipeline base path setting is ignored.
* else (if the config paths found in the pipelines.yml are relative paths)
  * if the pipeline base path is not set (this is, if it is the empty string ""),
    the absolute path of the pipelines.yml file is used as the pipeline base path
    (the assumption is, that relative paths in the pipelines.yml are relative to
    the location of the file it self).
  * if the pipeline base path is relative, it is converted to an absolute path by
    prefixing it with the current working directory.
  * if the pipeline base path is absolute, it is used as is.

the resulting absolute pipeline base path is prefixed to the relative config paths found in the pipelines.yml

See also: https://github.com/magnusbaeck/logstash-filter-verifier/issues/96#issuecomment-904878269
