### PR TITLE
Support input & output plugins for mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * [Test case file reference](#test-case-file-reference)
   * [Standalone mode / Logstash Filter Verifier before version 2.0](#standalone-mode--logstash-filter-verifier-before-version-20)
   * [Daemon mode](#daemon-mode)
-    * [Filter mock](#filter-mock)
+    * [Plugin mock](#plugin-mock)
 * [Migrating to the current test case file format](#migrating-to-the-current-test-case-file-format)
 * [Notes](#notes)
   * [The \-\-sockets flag](#the---sockets-flag)
@@ -400,8 +400,8 @@ have been added:
   The pipeline configuration may consist of multiple pipelines, that might be
   linked ([pipeline to pipeline communication](https://www.elastic.co/guide/en/logstash/current/pipeline-to-pipeline.html))
   or independent pipelines.
-* **Filter mock**  
-  Filter mock allows to replace (or remove) filter plugins in the Logstash
+* **Plugin mock**  
+  Plugin mock allows to replace (or remove) plugins in the Logstash
   configuration under test, that do not work during or that would potentially
   not produce the expected results test execution. Examples for such filter
   plugins are mainly plugins, that perform some sort of call out to a third
@@ -413,6 +413,8 @@ have been added:
   these plugins can be replaced with mocks. In particular the [mutate](https://www.elastic.co/guide/en/logstash/current/plugins-filters-mutate.html)
   and the [translate](https://www.elastic.co/guide/en/logstash/current/plugins-filters-translate.html)
   filters have proven to be helpful as replacements.
+  An other use case for mocks is to replace pipeline input and output plugins
+  in order to test pipelines in isolation.
 
 In order to execute a test case in daemon mode, first the daemon needs to be
 started (e.g. in its own terminal or shell):
@@ -443,7 +445,7 @@ needs to be started beforehand):
 
     $ /usr/local/bin/logstash-fitler-verifier daemon run --pipeline /tmp/logstash-filter-verifier/testdata/basic_pipeline.yml --pipeline-base /tmp/logstash-filter-verifier/testdata/basic_pipeline --testcase-dir /tmp/logstash-filter-verifier/testdata/testcases/basic_pipeline --add-missing-id
 
-More examples (e.g. multiple pipelines and filter mock) can be found in the
+More examples (e.g. multiple pipelines and plugin mock) can be found in the
 `testcases/` folder of this repository.
 
 
@@ -521,12 +523,12 @@ Ignored / obsolete fields:
 * `codec`
 
 
-#### Filter mock
+#### Plugin mock
 
-The filter mock config file (yaml) consists of an array of filter mock elements.
-Each filter mock element consists for the plugin id that should be replaced as
+The plugin mock config file (yaml) consists of an array of plugin mock elements.
+Each plugin mock element consists for the plugin id that should be replaced as
 well as the Logstash configuration string that should be used as the
-replacement. This string might be empty. In this case, the mocked filter is just
+replacement. This string might be empty. In this case, the mocked plugin is just
 removed from the Logstash configuration.
 
 Example:
@@ -534,7 +536,7 @@ Example:
 ```yaml
 - id: removeme
 - id: mockme
-  filter: |
+  mock: |
     mutate {
       replace => {
         "[message]" => "mocked"
@@ -542,7 +544,7 @@ Example:
     }
 ```
 
-Given the above filter mock configuration, the plugin with the ID `removeme` is
+Given the above plugin mock configuration, the plugin with the ID `removeme` is
 removed from the Logstash configuration. The plugin with the ID `mockme` is
 replaced with the given Logstash configuration.
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -117,7 +117,7 @@ func TestIntegration(t *testing.T) {
 		withoutPipeline bool
 		addMissingID    bool
 
-		filterMock string
+		pluginMock string
 	}{
 		{
 			name:         "basic_pipeline",
@@ -157,7 +157,12 @@ func TestIntegration(t *testing.T) {
 		{
 			name: "filtermock",
 
-			filterMock: "testdata/mocks/filtermock.yml",
+			pluginMock: "testdata/mocks/filtermock.yml",
+		},
+		{
+			name: "inputoutputmock",
+
+			pluginMock: "testdata/mocks/inputoutputmock.yml",
 		},
 		{
 			name: "special_chars",
@@ -195,7 +200,7 @@ func TestIntegration(t *testing.T) {
 				pipelineBaseDir,
 				logstashConfig,
 				"testdata/testcases/"+tc.name,
-				tc.filterMock,
+				tc.pluginMock,
 				"@metadata",
 				tc.debug,
 				tc.addMissingID,

--- a/internal/app/daemon_run.go
+++ b/internal/app/daemon_run.go
@@ -24,8 +24,8 @@ func makeDaemonRunCmd() *cobra.Command {
 	_ = viper.BindPFlag("logstash-config", cmd.Flags().Lookup("logstash-config"))
 	cmd.Flags().StringP("testcase-dir", "t", "", "directory containing the test case files")
 	_ = viper.BindPFlag("testcase-dir", cmd.Flags().Lookup("testcase-dir"))
-	cmd.Flags().String("filter-mock", "", "path to a yaml file containing the definition for the filter mocks.")
-	_ = viper.BindPFlag("filter-mock", cmd.Flags().Lookup("filter-mock"))
+	cmd.Flags().String("plugin-mock", "", "path to a yaml file containing the definition for the plugin mocks.")
+	_ = viper.BindPFlag("plugin-mock", cmd.Flags().Lookup("plugin-mock"))
 	cmd.Flags().Bool("debug", false, "enable debug mode; e.g. prevents stripping '__lfv' data from Logstash events")
 	_ = viper.BindPFlag("debug", cmd.Flags().Lookup("debug"))
 	cmd.Flags().String("metadata-key", "@metadata", "Key under which the content of the `@metadata` field is exposed in the returned events.")
@@ -43,7 +43,7 @@ func runDaemonRun(_ *cobra.Command, args []string) error {
 	pipelineBase := viper.GetString("pipeline-base")
 	logstashConfig := viper.GetString("logstash-config")
 	testcaseDir := viper.GetString("testcase-dir")
-	filterMock := viper.GetString("filter-mock")
+	pluginMock := viper.GetString("plugin-mock")
 	debug := viper.GetBool("debug")
 	metadataKey := viper.GetString("metadata-key")
 	addMissingID := viper.GetBool("add-missing-id")
@@ -52,7 +52,7 @@ func runDaemonRun(_ *cobra.Command, args []string) error {
 		return errors.New("--pipeline and --logstash-config flags are mutual exclusive")
 	}
 
-	t, err := run.New(socket, log, pipeline, pipelineBase, logstashConfig, testcaseDir, filterMock, metadataKey, debug, addMissingID)
+	t, err := run.New(socket, log, pipeline, pipelineBase, logstashConfig, testcaseDir, pluginMock, metadataKey, debug, addMissingID)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/pipeline/pipeline_test.go
+++ b/internal/daemon/pipeline/pipeline_test.go
@@ -89,10 +89,10 @@ func TestValidate(t *testing.T) {
 			a, err := pipeline.New(test.pipeline, test.basePath)
 			is.NoErr(err)
 
-			err = a.Validate(false)
+			err = a.Validate(pipeline.NoopPreprocessor, false)
 			is.True(err != nil == test.wantValidateErr) // Validate error
 
-			err = a.Validate(true)
+			err = a.Validate(pipeline.NoopPreprocessor, true)
 			is.NoErr(err)
 		})
 	}

--- a/internal/daemon/pluginmock/pluginmock.go
+++ b/internal/daemon/pluginmock/pluginmock.go
@@ -1,11 +1,13 @@
-// Filter mocks allow to replace an existing filter, identified by its ID, in
-// the config with a mock implementation.
+// Plugin mocks allow to replace an existing plugin (input, output, filter),
+// identified by its ID, in the config with a mock implementation.
 // This comes in handy, if a filter does perform a call out to an external
 // system e.g. lookup in Elasticsearch.
+// An other use case is to replace pipeline input or outputs to test such
+// pipelines in isolation.
 // Because the existing filter is replaced with whatever is present in
-// `filter`, it is also possible to remove a filter by simple keep the
-// `filter` empty (or not present).
-package filtermock
+// `mock`, it is also possible to remove a plugin by simple keep the
+// `mock` empty (or not present).
+package pluginmock
 
 import (
 	"fmt"
@@ -22,7 +24,7 @@ type Mock struct {
 	// ID of the Logstash filter to be mocked.
 	ID string `json:"id" yaml:"id"`
 
-	// Logstash configuration snippet of the replacement filter. E.g.
+	// Logstash configuration snippet of the replacement plugin. E.g.
 	//
 	//     # Constant lookup, does return the same result for each event
 	//     mutate {
@@ -30,7 +32,7 @@ type Mock struct {
 	//         "[field]" => "value"
 	//       }
 	//     }
-	Filter string `json:"filter,omitempty" yaml:"filter,omitempty"`
+	Mock string `json:"mock,omitempty" yaml:"mock,omitempty"`
 }
 
 func FromFile(filename string) (Mocks, error) {
@@ -50,38 +52,40 @@ func FromFile(filename string) (Mocks, error) {
 		return Mocks{}, err
 	}
 
-	filtermocks := make(Mocks, len(mocks))
+	pluginmocks := make(Mocks, len(mocks))
 
 	for _, m := range mocks {
-		if m.Filter == "" {
-			filtermocks[m.ID] = nil
+		if m.Mock == "" {
+			pluginmocks[m.ID] = nil
 			continue
 		}
 
-		wrappedFilter := []byte(fmt.Sprintf("filter {\n%s\n}", m.Filter))
-		cfg, err := config.Parse("", wrappedFilter)
+		// The mock plugin definition is wrapped with filter to form a valid
+		// Logstash config, which can then be parsed.
+		wrappedPlugin := []byte(fmt.Sprintf("filter {\n%s\n}", m.Mock))
+		cfg, err := config.Parse("", wrappedPlugin)
 		if err != nil {
 			return Mocks{}, err
 		}
 
-		var filter ast.Plugin
+		var plugin ast.Plugin
 		var recoverErr interface{}
 
 		func() {
 			defer func() {
 				recoverErr = recover()
 			}()
-			filter = cfg.(ast.Config).Filter[0].BranchOrPlugins[0].(ast.Plugin)
+			plugin = cfg.(ast.Config).Filter[0].BranchOrPlugins[0].(ast.Plugin)
 		}()
 
 		if recoverErr != nil {
-			return Mocks{}, errors.Errorf("failed to parse mock filter: %s", m.Filter)
+			return Mocks{}, errors.Errorf("failed to parse mock: %s", m.Mock)
 		}
 
-		filtermocks[m.ID] = &filter
+		pluginmocks[m.ID] = &plugin
 	}
 
-	return filtermocks, nil
+	return pluginmocks, nil
 }
 
 type Mocks map[string]*ast.Plugin

--- a/testdata/inputoutputmock.yml
+++ b/testdata/inputoutputmock.yml
@@ -1,0 +1,2 @@
+- pipeline.id: main
+  path.config: "*.conf"

--- a/testdata/inputoutputmock/main.conf
+++ b/testdata/inputoutputmock/main.conf
@@ -1,0 +1,18 @@
+input {
+  pipeline {
+    id => input
+  }
+}
+
+filter {
+  mutate {
+    id => filter
+    add_tag => [ "sut_passed" ]
+  }
+}
+
+output {
+  pipeline {
+    id => output
+  }
+}

--- a/testdata/mocks/filtermock.yml
+++ b/testdata/mocks/filtermock.yml
@@ -2,7 +2,7 @@
 
 - id: removeme
 - id: mockme
-  filter: |
+  mock: |
     mutate {
       replace => {
         "[message]" => "mocked"

--- a/testdata/mocks/inputoutputmock.yml
+++ b/testdata/mocks/inputoutputmock.yml
@@ -1,0 +1,8 @@
+---
+
+- id: input
+  mock: |
+    stdin {}
+- id: output
+  mock: |
+    stdout {}

--- a/testdata/testcases/inputoutputmock/testcase.json
+++ b/testdata/testcases/inputoutputmock/testcase.json
@@ -1,0 +1,25 @@
+{
+  "fields": {
+    "type": "syslog"
+  },
+  "ignore": [
+    "@timestamp"
+  ],
+  "input_plugin": "input",
+  "testcases": [
+    {
+      "input": [
+        "test case message"
+      ],
+      "expected": [
+        {
+          "message": "test case message",
+          "tags": [
+            "sut_passed"
+          ],
+          "type": "syslog"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In order to support isolated testing of Logstash configurations,
which use pipeline input and output plugins, the mocking is
extended to all types of plugins.

See also discussion: https://github.com/magnusbaeck/logstash-filter-verifier/issues/96#issuecomment-906726509
