### PR TITLE
Align Logstash bracket field syntax with Logstash

### DIFF
--- a/internal/testcase/helper.go
+++ b/internal/testcase/helper.go
@@ -26,8 +26,8 @@ func parseAllBracketProperties(data map[string]interface{}) map[string]interface
 
 // extractBracketFields convert bracket notation to slice of key.
 func extractBracketFields(key string) []string {
-	rValidator := regexp.MustCompile(`^(\[\w+\])+$`)
-	rExtractField := regexp.MustCompile(`\[(\w+)\]`)
+	rValidator := regexp.MustCompile(`^(\[[^\[\],]+\])+$`)
+	rExtractField := regexp.MustCompile(`\[([^\[\],]+)\]`)
 	listKeys := make([]string, 0, 1)
 
 	if rValidator.MatchString(key) {

--- a/internal/testcase/testcase_test.go
+++ b/internal/testcase/testcase_test.go
@@ -462,6 +462,8 @@ func TestConvertBracketFields(t *testing.T) {
 			"type":                "test",
 			"[log][file][path]":   "/tmp/file.log",
 			"[log][origin][file]": "test.java",
+			"[log][special_field.name-with some+spice]": "value",
+			"[@metadata][field]":                        "value",
 		},
 		Codec: "json_lines",
 		InputLines: []string{
@@ -487,6 +489,10 @@ func TestConvertBracketFields(t *testing.T) {
 				"origin": map[string]interface{}{
 					"file": "test.java",
 				},
+				"special_field.name-with some+spice": "value",
+			},
+			"@metadata": map[string]interface{}{
+				"field": "value",
 			},
 		},
 		Codec: "json_lines",

--- a/testdata/testcases/testcases_event/testcases_metadata_logstash.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_logstash.json
@@ -1,0 +1,22 @@
+{
+  "ignore": [
+    "@timestamp"
+  ],
+  "input_plugin": "stdin",
+  "export_metadata": true,
+  "testcases": [
+    {
+      "fields": {
+        "[@metadata][testcase]": "value"
+      },
+      "expected": [
+        {
+          "@metadata": {
+            "filter": "value",
+            "testcase": "value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/testcases/testcases_event/testcases_metadata_logstash_global.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_logstash_global.json
@@ -1,0 +1,26 @@
+{
+  "ignore": [
+    "@timestamp"
+  ],
+  "input_plugin": "stdin",
+  "export_metadata": true,
+  "fields": {
+    "[@metadata][global]": "value"
+  },
+  "testcases": [
+    {
+      "fields": {
+        "key": "value"
+      },
+      "expected": [
+        {
+          "@metadata": {
+            "filter": "value",
+            "global": "value"
+          },
+          "key": "value"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/testcases/testcases_event/testcases_metadata_nested.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_nested.json
@@ -1,0 +1,24 @@
+{
+  "ignore": [
+    "@timestamp"
+  ],
+  "input_plugin": "stdin",
+  "export_metadata": true,
+  "testcases": [
+    {
+      "fields": {
+        "@metadata": {
+          "testcase": "value"
+        }
+      },
+      "expected": [
+        {
+          "@metadata": {
+            "filter": "value",
+            "testcase": "value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/testcases/testcases_event/testcases_metadata_nested_global.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_nested_global.json
@@ -1,0 +1,28 @@
+{
+  "ignore": [
+    "@timestamp"
+  ],
+  "input_plugin": "stdin",
+  "export_metadata": true,
+  "fields": {
+    "@metadata": {
+      "global": "value"
+    }
+  },
+  "testcases": [
+    {
+      "fields": {
+        "key": "value"
+      },
+      "expected": [
+        {
+          "@metadata": {
+            "filter": "value",
+            "global": "value"
+          },
+          "key": "value"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/testcases_event/testcases_event.conf
+++ b/testdata/testcases_event/testcases_event.conf
@@ -3,6 +3,12 @@ input {
     id => "stdin"
   }
 }
+filter {
+  mutate {
+    id => "add_metadata"
+    add_field => { "[@metadata][filter]" => "value" }
+  }
+}
 output {
   stdout {
     id => "stdout"


### PR DESCRIPTION
Align bracket field regex with:
https://www.elastic.co/guide/en/logstash/current/field-references-deepdive.html#formal-grammar-field-name
https://github.com/elastic/logstash/blob/c698aa224b44c7356fbfeb58ebb0c4a66d72dc71/logstash-core/lib/logstash/config/grammar.treetop#L236

Fixes: #142
