### PR TITLE
Change default loglevel from WARNING to INFO

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -33,7 +33,7 @@ func Execute(version string, stdout, stderr io.Writer) int {
 	viper.AddConfigPath("/etc/logstash-filter-verifier/")
 
 	// Setup default values
-	viper.SetDefault("loglevel", "WARNING")
+	viper.SetDefault("loglevel", "INFO")
 	viper.SetDefault("socket", "/tmp/logstash-filter-verifier.sock")
 	viper.SetDefault("logstash.path", "/usr/share/logstash/bin/logstash")
 	viper.SetDefault("inflight-shutdown-timeout", 10*time.Second)
@@ -76,7 +76,7 @@ func makeRootCmd(version string) *cobra.Command {
 
 	rootCmd.InitDefaultVersionFlag()
 
-	rootCmd.PersistentFlags().String("loglevel", "WARNING", "Set the desired level of logging (one of: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG).")
+	rootCmd.PersistentFlags().String("loglevel", "INFO", "Set the desired level of logging (one of: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG).")
 	_ = viper.BindPFlag("loglevel", rootCmd.PersistentFlags().Lookup("loglevel"))
 
 	rootCmd.AddCommand(makeStandaloneCmd())


### PR DESCRIPTION
With WARNING as the default loglevel the daemon wouldn't emit any useful status messages to let you know it has actually started up and is ready to be used. INFO will give users a few more messages overall but there's no dramatic increase and it's not likely to be regarded as spammy.