### PR TITLE
Upgrade golangci-lint and enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,21 +2,29 @@
 linters:
   disable-all: true
   enable:
+    - asciicheck
+    - bidichk
     - deadcode
+    - durationcheck
+    - errname
+    - exportloopref
     - gocyclo
     - godot
     - gofmt
     - gosec
     - gosimple
     - ineffassign
+    - makezero
     - misspell
     - prealloc
     - staticcheck
     - structcheck
+    - tenv
     - typecheck
     - unconvert
     - unused
     - varcheck
+    - wastedassign
     - whitespace
 
 linters-settings:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ PROTOC_GEN_GO      := $(GOBIN)/protoc-gen-go$(EXEC_SUFFIX)
 PROTOC_GEN_GO_GRPC := $(GOBIN)/protoc-gen-go-grpc$(EXEC_SUFFIX)
 MOQ                := $(GOBIN)/moq$(EXEC_SUFFIX)
 
-GOLANGCI_LINT_VERSION := v1.32.2
+GOLANGCI_LINT_VERSION := v1.43.0
 
 .PHONY: all
 all: $(PROGRAM)$(EXEC_SUFFIX)


### PR DESCRIPTION
The new linters are reasonable and didn't require any changes to the existing code.