### PR TITLE
Pass --keep-env values to DetectVersion function.

### DIFF
--- a/internal/app/daemon/daemon.go
+++ b/internal/app/daemon/daemon.go
@@ -100,7 +100,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	env := standalonelogstash.GetLimitedEnvironment(os.Environ(), d.keptEnvVars)
 
-	logstashVersion, err := standalonelogstash.DetectVersion(d.logstashPath, env)
+	logstashVersion, err := standalonelogstash.DetectVersion(d.logstashPath, d.keptEnvVars)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
--keep-env was not working in daemon mode. I found daemon app was passing full kept environment as argument to DetectVersion function, so later RestrictedEnvironment was not composing well.

Solves #181 