### PR TITLE
Use standard gopkg.in/yaml.v2 package for tests

### DIFF
--- a/internal/testcase/testcase.go
+++ b/internal/testcase/testcase.go
@@ -11,14 +11,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 
 	unjson "github.com/hashicorp/packer/common/json"
 	"github.com/imkira/go-observer"
-	"github.com/mikefarah/yaml/v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/magnusbaeck/logstash-filter-verifier/v2/internal/logging"
 	"github.com/magnusbaeck/logstash-filter-verifier/v2/internal/logstash"
@@ -186,8 +185,6 @@ func New(reader io.Reader, configType string) (*TestCaseSet, error) {
 			return nil, err
 		}
 	} else {
-		// Fix issue https://github.com/go-yaml/yaml/issues/139
-		yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
 		if err = yaml.Unmarshal(buf, &tcs); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The use of github.com/mikefarah/yaml/v2 was motivated because the default type for maps was `map[interface{}]interface{}` instead of `map[string]interface{}`. This is still the case, but this does not seem to be a problem anymore. The fork used was forcibly synced with the original package and we now get:

```
verifying github.com/mikefarah/yaml/v2@v2.4.0/go.mod: checksum mismatch
        downloaded: h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
        go.sum:     h1:ahVqZF4n1W4NqwvVnZzC4es67xsW9uR/RRf2RRxieJU=
```