### PR TITLE
Logstash 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,37 @@ present:
 * Proto buffer compiler (`protobuf-compiler`)
 
 
+### Run Integration Tests
+
+In order to run the integration tests, the following preperation is needed:
+
+1. Run `go run . setup 8.12.1` to download Logstash version 8.12.1
+2. Prepare a `logstash-filter-verifier.yml` config file, which points to the
+   downloaded Logstash version, e.g.
+
+   ```yaml
+   ---
+
+   loglevel: debug
+   logstash:
+     path: ./3rdparty/logstash-8.12.1-linux-x86_64/bin/logstash
+   keep-envs:
+     - TESTMODE
+   metadata-key: __metadata
+   ```
+
+3. Execute the integration tests by providing the respective env var:
+
+   `INTEGRATION_TEST=1 go test -v .`
+
+   or
+
+   ```shell
+   export INTEGRATION_TEST=1
+   go test -v .
+   ```
+
+
 ## Known limitations and future work
 
 * Some log formats don't include all timestamp components. For

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ present:
 
 ### Run Integration Tests
 
-In order to run the integration tests, the following preperation is needed:
+In order to run the integration tests, the following preparation is needed:
 
 1. Run `go run . setup 8.12.1` to download Logstash version 8.12.1
 2. Prepare a `logstash-filter-verifier.yml` config file, which points to the

--- a/integration_test.go
+++ b/integration_test.go
@@ -110,6 +110,7 @@ func TestIntegration(t *testing.T) {
 		repeat int
 
 		minimumVersion *semver.Version
+		maximumVersion *semver.Version // exclusive
 
 		// optional integration tests require additional logstash plugins,
 		// which are not provided by a default installation.
@@ -150,6 +151,14 @@ func TestIntegration(t *testing.T) {
 		},
 		{
 			name: "codec_test",
+		},
+		{
+			name:           "codec_version_7_test",
+			maximumVersion: semver.MustParse("8.0.0"),
+		},
+		{
+			name:           "codec_version_8_test",
+			minimumVersion: semver.MustParse("8.0.0"),
 		},
 		{
 			name:     "codec_optional_test",
@@ -199,7 +208,11 @@ func TestIntegration(t *testing.T) {
 			is := is.New(t)
 
 			if tc.minimumVersion != nil && tc.minimumVersion.GreaterThan(version) {
-				t.Skipf("Logstash minimum version not satisfied, require %s, have %s", tc.minimumVersion.String(), version.String())
+				t.Skipf("Logstash minimum version not satisfied, require at least %s, have %s", tc.minimumVersion.String(), version.String())
+			}
+
+			if tc.maximumVersion != nil && tc.maximumVersion.LessThan(version) {
+				t.Skipf("Logstash maximum version not satisfied, require less than %s, have %s", tc.maximumVersion.String(), version.String())
 			}
 
 			if tc.optional && os.Getenv("INTEGRATION_TEST_OPTIONAL") != "1" {

--- a/internal/daemon/instance/logstash/processors.go
+++ b/internal/daemon/instance/logstash/processors.go
@@ -98,6 +98,13 @@ func (i *instance) logstashLogProcessor(t *tail.Tail) {
 			case "Pipelines running":
 				rp := gjson.Get(line.Text, `logEvent.running_pipelines.0.metaClass.metaClass.metaClass.running_pipelines`).String()
 				runningPipelines := extractPipelines(rp)
+				if runningPipelines == nil {
+					// Since Logstash 8.11.x, the running pipelines are directly in the logEvent.
+					rps := gjson.Get(line.Text, `logEvent.running_pipelines`).Array()
+					for _, rp := range rps {
+						runningPipelines = append(runningPipelines, rp.String())
+					}
+				}
 				i.log.Debugf("taillog: -> pipeline running: %v", runningPipelines)
 
 				i.controller.PipelinesReady(runningPipelines...)

--- a/testdata/codec_test/codec_test.conf
+++ b/testdata/codec_test/codec_test.conf
@@ -1,14 +1,5 @@
 input {
   stdin {
-    id => cef
-    codec => cef
-    add_field => {
-      "input_codec" => "cef"
-    }
-    tags => [ "input_codec_cef" ]
-  }
-
-  stdin {
     id => edn
     codec => edn
     add_field => {

--- a/testdata/codec_version_7_test.yml
+++ b/testdata/codec_version_7_test.yml
@@ -1,0 +1,2 @@
+- pipeline.id: main
+  path.config: "*.conf"

--- a/testdata/codec_version_7_test/codec_test.conf
+++ b/testdata/codec_version_7_test/codec_test.conf
@@ -1,0 +1,10 @@
+input {
+  stdin {
+    id => cef
+    codec => cef
+    add_field => {
+      "input_codec" => "cef"
+    }
+    tags => [ "input_codec_cef" ]
+  }
+}

--- a/testdata/codec_version_7_test/output.conf
+++ b/testdata/codec_version_7_test/output.conf
@@ -1,0 +1,5 @@
+output {
+  stdout {
+    id => stdout
+  }
+}

--- a/testdata/codec_version_8_test.yml
+++ b/testdata/codec_version_8_test.yml
@@ -1,0 +1,2 @@
+- pipeline.id: main
+  path.config: "*.conf"

--- a/testdata/codec_version_8_test/codec_test.conf
+++ b/testdata/codec_version_8_test/codec_test.conf
@@ -1,0 +1,10 @@
+input {
+  stdin {
+    id => cef
+    codec => cef
+    add_field => {
+      "input_codec" => "cef"
+    }
+    tags => [ "input_codec_cef" ]
+  }
+}

--- a/testdata/codec_version_8_test/output.conf
+++ b/testdata/codec_version_8_test/output.conf
@@ -1,0 +1,5 @@
+output {
+  stdout {
+    id => stdout
+  }
+}

--- a/testdata/issue_150/main.conf
+++ b/testdata/issue_150/main.conf
@@ -8,6 +8,7 @@ filter {
   clone {
     id => "clone"
     clones => [ "cloned_event" ]
+    ecs_compatibility => "disabled"
   }
 }
 

--- a/testdata/issue_150a/main.conf
+++ b/testdata/issue_150a/main.conf
@@ -8,6 +8,7 @@ filter {
   clone {
     id => "clone"
     clones => [ "cloned1", "cloned2", "cloned3" ]
+    ecs_compatibility => "disabled"
   }
 }
 

--- a/testdata/issue_153/main.conf
+++ b/testdata/issue_153/main.conf
@@ -9,6 +9,7 @@ filter {
   clone {
     id => "clone"
     clones => [ "cloned-event" ]
+    ecs_compatibility => "disabled"
   }
 
   if ([type] == "cloned-event") {

--- a/testdata/testcases/basic_logstash_config_dir/testcase1.json
+++ b/testdata/testcases/basic_logstash_config_dir/testcase1.json
@@ -3,7 +3,8 @@
     "type": "syslog"
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/basic_logstash_config_file.conf/testcase1.json
+++ b/testdata/testcases/basic_logstash_config_file.conf/testcase1.json
@@ -3,7 +3,8 @@
     "type": "syslog"
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/basic_pipeline/testcase1.json
+++ b/testdata/testcases/basic_pipeline/testcase1.json
@@ -3,7 +3,8 @@
     "type": "syslog"
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/basic_pipeline/testcase2.json
+++ b/testdata/testcases/basic_pipeline/testcase2.json
@@ -4,7 +4,8 @@
     "second": "2"
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/basic_pipeline_debug/testcase1.json
+++ b/testdata/testcases/basic_pipeline_debug/testcase1.json
@@ -3,7 +3,8 @@
     "type": "syslog"
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin-with-dash",
   "testcases": [

--- a/testdata/testcases/basic_pipeline_debug/testcase2.json
+++ b/testdata/testcases/basic_pipeline_debug/testcase2.json
@@ -4,7 +4,8 @@
     "second": "2"
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin-with-dash",
   "export_metadata": true,

--- a/testdata/testcases/codec_optional_test/csv.json
+++ b/testdata/testcases/codec_optional_test/csv.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "csv",
   "testcases": [

--- a/testdata/testcases/codec_test/edn.json
+++ b/testdata/testcases/codec_test/edn.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "edn",
   "testcases": [

--- a/testdata/testcases/codec_test/edn_lines.json
+++ b/testdata/testcases/codec_test/edn_lines.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "edn_lines",
   "testcases": [

--- a/testdata/testcases/codec_test/graphite.json
+++ b/testdata/testcases/codec_test/graphite.json
@@ -1,4 +1,8 @@
 {
+  "ignore": [
+    "@timestamp",
+    "event"
+  ],
   "input_plugin": "graphite",
   "testcases": [
     {
@@ -8,13 +12,11 @@
       ],
       "expected": [
         {
-          "@timestamp": "2021-04-02T17:37:50.000Z",
           "foo.bar.metric1": 100,
           "input_codec": "graphite",
           "tags": [ "input_codec_graphite" ]
         },
         {
-          "@timestamp": "2021-04-02T17:37:50.000Z",
           "foo.bar.metric2": 200,
           "input_codec": "graphite",
           "tags": [ "input_codec_graphite" ]

--- a/testdata/testcases/codec_test/json.json
+++ b/testdata/testcases/codec_test/json.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "json",
   "testcases": [

--- a/testdata/testcases/codec_test/json_lines.json
+++ b/testdata/testcases/codec_test/json_lines.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "json_lines",
   "testcases": [

--- a/testdata/testcases/codec_test/line.json
+++ b/testdata/testcases/codec_test/line.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "line",
   "testcases": [

--- a/testdata/testcases/codec_test/multiline.json
+++ b/testdata/testcases/codec_test/multiline.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "multiline",
   "testcases": [

--- a/testdata/testcases/codec_test/plain.json
+++ b/testdata/testcases/codec_test/plain.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "plain",
   "testcases": [

--- a/testdata/testcases/codec_version_7_test/cef.json
+++ b/testdata/testcases/codec_version_7_test/cef.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "cef",
   "testcases": [

--- a/testdata/testcases/codec_version_8_test/cef.json
+++ b/testdata/testcases/codec_version_8_test/cef.json
@@ -1,0 +1,36 @@
+{
+  "ignore": [
+    "@timestamp",
+    "event"
+  ],
+  "input_plugin": "cef",
+  "testcases": [
+    {
+      "input": [
+        "CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232"
+      ],
+      "expected": [
+        {
+          "cef": {
+            "name": "trojan successfully stopped",
+            "version": "0"
+          },
+          "destination": {
+            "ip": "12.121.122.82"
+          },
+          "input_codec": "cef",
+          "observer": {
+            "product": "threatmanager",
+            "vendor": "security",
+            "version": "1.0"
+          },
+          "source": {
+            "ip": "10.0.0.192",
+            "port": "1232"
+          },
+          "tags": [ "input_codec_cef" ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/testcases/conditional_output/conditional_output.json
+++ b/testdata/testcases/conditional_output/conditional_output.json
@@ -2,7 +2,8 @@
   "fields": {
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/drop_and_split/drop.json
+++ b/testdata/testcases/drop_and_split/drop.json
@@ -2,7 +2,8 @@
   "fields": {
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/drop_and_split/drop_all.json
+++ b/testdata/testcases/drop_and_split/drop_all.json
@@ -2,7 +2,8 @@
   "fields": {
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/drop_and_split/split.json
+++ b/testdata/testcases/drop_and_split/split.json
@@ -2,7 +2,8 @@
   "fields": {
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/filtermock/filtermock.json
+++ b/testdata/testcases/filtermock/filtermock.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/inputoutputmock/testcase.json
+++ b/testdata/testcases/inputoutputmock/testcase.json
@@ -3,7 +3,8 @@
     "type": "syslog"
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "input",
   "testcases": [

--- a/testdata/testcases/issue_150/testcase.yml
+++ b/testdata/testcases/issue_150/testcase.yml
@@ -5,6 +5,7 @@ export_outputs: true
 ignore:
   - "@timestamp"
   - "message"
+  - "event"
 testcases:
   - input:
       - >

--- a/testdata/testcases/issue_150a/testcase.yml
+++ b/testdata/testcases/issue_150a/testcase.yml
@@ -4,6 +4,7 @@ fields:
 ignore:
   - "@timestamp"
   - "message"
+  - "event"
 testcases:
   - input:
       - >

--- a/testdata/testcases/issue_153/testcase.yml
+++ b/testdata/testcases/issue_153/testcase.yml
@@ -3,6 +3,7 @@ input_plugin: "input"
 ignore:
   - "@timestamp"
   - type
+  - event
 testcases:
   - input:
       - >

--- a/testdata/testcases/issue_155/testcase.yml
+++ b/testdata/testcases/issue_155/testcase.yml
@@ -1,6 +1,7 @@
 ---
 ignore:
   - "@timestamp"
+  - "event"
 input_plugin: "json_lines"
 testcases:
   - input:

--- a/testdata/testcases/issue_166/testcase.yml
+++ b/testdata/testcases/issue_166/testcase.yml
@@ -1,6 +1,7 @@
 ---
 ignore:
   - "@timestamp"
+  - "event"
 input_plugin: "input"
 testcases:
   - input:

--- a/testdata/testcases/issue_175/testcase.yml
+++ b/testdata/testcases/issue_175/testcase.yml
@@ -1,6 +1,7 @@
 input_plugin: "input"
 ignore:
   - "@timestamp"
+  - "event"
 testcases:
   - input:
       - >-

--- a/testdata/testcases/multiple_parallel_outputs/multiple_parallel_outputs.json
+++ b/testdata/testcases/multiple_parallel_outputs/multiple_parallel_outputs.json
@@ -2,7 +2,8 @@
   "fields": {
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/multiple_parallel_outputs/multiple_parallel_outputs_export_outputs.json
+++ b/testdata/testcases/multiple_parallel_outputs/multiple_parallel_outputs_export_outputs.json
@@ -3,7 +3,8 @@
   "fields": {
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "export_outputs": true,

--- a/testdata/testcases/pipeline_to_pipeline/pipeline_to_pipeline.json
+++ b/testdata/testcases/pipeline_to_pipeline/pipeline_to_pipeline.json
@@ -2,7 +2,8 @@
   "fields": {
   },
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stage1_input",
   "testcases": [

--- a/testdata/testcases/special_chars/testcases.json
+++ b/testdata/testcases/special_chars/testcases.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "testcases": [

--- a/testdata/testcases/testcases_event/testcases.json
+++ b/testdata/testcases/testcases_event/testcases.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "fields": {

--- a/testdata/testcases/testcases_event/testcases_metadata_logstash.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_logstash.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "export_metadata": true,

--- a/testdata/testcases/testcases_event/testcases_metadata_logstash_global.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_logstash_global.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "export_metadata": true,

--- a/testdata/testcases/testcases_event/testcases_metadata_nested.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_nested.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "export_metadata": true,

--- a/testdata/testcases/testcases_event/testcases_metadata_nested_global.json
+++ b/testdata/testcases/testcases_event/testcases_metadata_nested_global.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
-    "@timestamp"
+    "@timestamp",
+    "event"
   ],
   "input_plugin": "stdin",
   "export_metadata": true,


### PR DESCRIPTION
This PR restores compatibility with Logstash 8:

* Make the integration tests pass with Logstash 8.x
* Adjust the detection of the running pipelines to the changed log format of Logstash > 8.11.x
* Update README with instructions on how to run the integration tests

These Changes have been successfully tested with Logstash 7.x (namely 7.13.0), Logstash 8.x (namely 8.0.2, 8.9.2, 8.11.4, 8.12.1, 8.13.4) but it might also work with other versions.
Logstash Filter Verifier does not work with Logstash 8.10.x due to a brocken JSON serializer used for logging (see https://github.com/elastic/logstash/pull/15564).