### PR TITLE
README.md: Add missing ToC entry for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   * [@metadata field](#metadata-field)
 * [Development](#development)
   * [Dependencies](#dependencies)
+  * [Run Integration Tests](#run-integration-tests)
 * [Known limitations and future work](#known-limitations-and-future-work)
 * [License](#license)
 


### PR DESCRIPTION
This entry was missing from commit e77dc8a where the section was added.