### PR TITLE
Resolve symlinks to make test more portable.

### DIFF
--- a/internal/testcase/testcase_test.go
+++ b/internal/testcase/testcase_test.go
@@ -113,7 +113,10 @@ func TestNewFromFile(t *testing.T) {
 		"filename.yaml",
 	}
 	for _, filename := range filenames {
-		tempdir := t.TempDir()
+		tempdir, err := filepath.EvalSymlinks(t.TempDir())
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
 		olddir, err := os.Getwd()
 		if err != nil {
 			t.Fatalf(err.Error())


### PR DESCRIPTION
This unbreaks tests on systems where `/tmp` is linked to `/private/tmp`, for example.

```
2024/06/24 13:49:31 --- FAIL: TestNewFromFile (0.00s)
2024/06/24 13:49:31     testcase_test.go:141: Expected test case path to be "/tmp/TestNewFromFile730042975/001/filename.json", got "/private/tmp/TestNewFromFile730042975/001/filename.json" instead.
2024/06/24 13:49:31 FAIL
```