### PR TITLE
internal/testcase: Support bracket field references for testcases

### DIFF
--- a/internal/testcase/helper.go
+++ b/internal/testcase/helper.go
@@ -1,6 +1,7 @@
 package testcase
 
 import (
+	"encoding/json"
 	"reflect"
 	"regexp"
 )
@@ -22,6 +23,19 @@ func parseAllBracketProperties(data map[string]interface{}) map[string]interface
 	}
 
 	return result
+}
+
+// parseAllBracketPropertiesInJSON converts a JSON string with attributes
+// that may use the bracket notation (e.g. "[foo][bar]") in their keys into
+// a JSON string where the the field references have been expanded.
+func parseAllBracketPropertiesInJSON(jsonString string) (string, error) {
+	var jsonObj map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonString), &jsonObj); err != nil {
+		return "", err
+	}
+	jsonObj = parseAllBracketProperties(jsonObj)
+	b, err := json.Marshal(jsonObj)
+	return string(b), err
 }
 
 // extractBracketFields convert bracket notation to slice of key.

--- a/internal/testcase/testcase.go
+++ b/internal/testcase/testcase.go
@@ -144,7 +144,7 @@ func (tcs *TestCaseSet) convertBracketFields() error {
 
 	// Convert fields in input json string
 	if tcs.Codec == "json_lines" {
-		// Perform bracket transform on deprecated top-level input lines
+		// Perform bracket transform on deprecated top-level input lines.
 		for i, line := range tcs.InputLines {
 			s, err := parseAllBracketPropertiesInJSON(line)
 			if err != nil {
@@ -153,7 +153,7 @@ func (tcs *TestCaseSet) convertBracketFields() error {
 			tcs.InputLines[i] = s
 		}
 
-		// Perform bracket transform on input lines inside the test cases
+		// Perform bracket transform on input lines inside the test cases.
 		for i := range tcs.TestCases {
 			for j, line := range tcs.TestCases[i].InputLines {
 				s, err := parseAllBracketPropertiesInJSON(line)

--- a/internal/testcase/testcase.go
+++ b/internal/testcase/testcase.go
@@ -144,17 +144,24 @@ func (tcs *TestCaseSet) convertBracketFields() error {
 
 	// Convert fields in input json string
 	if tcs.Codec == "json_lines" {
+		// Perform bracket transform on deprecated top-level input lines
 		for i, line := range tcs.InputLines {
-			var jsonObj map[string]interface{}
-			if err := json.Unmarshal([]byte(line), &jsonObj); err != nil {
-				return err
-			}
-			jsonObj = parseAllBracketProperties(jsonObj)
-			data, err := json.Marshal(jsonObj)
+			s, err := parseAllBracketPropertiesInJSON(line)
 			if err != nil {
 				return err
 			}
-			tcs.InputLines[i] = string(data)
+			tcs.InputLines[i] = s
+		}
+
+		// Perform bracket transform on input lines inside the test cases
+		for i := range tcs.TestCases {
+			for j, line := range tcs.TestCases[i].InputLines {
+				s, err := parseAllBracketPropertiesInJSON(line)
+				if err != nil {
+					return err
+				}
+				tcs.TestCases[i].InputLines[j] = s
+			}
 		}
 	}
 

--- a/internal/testcase/testcase_test.go
+++ b/internal/testcase/testcase_test.go
@@ -67,26 +67,60 @@ func TestNew(t *testing.T) {
 				IgnoredFields: []string{"@version"},
 			},
 		},
-		// No handle input with bracket notation when codec is line
+		// Ignore bracket notation in TCS input lines when codec is line
 		{
 			input: `{"input": ["{\"[test][path]\": \"test\"}"]}`,
 			expected: TestCaseSet{
 				Codec:         "line",
-				InputLines:    []string{"{\"[test][path]\": \"test\"}"},
+				InputLines:    []string{`{"[test][path]": "test"}`},
 				IgnoredFields: []string{"@version"},
 				InputFields:   logstash.FieldSet{},
 				Events:        []logstash.FieldSet{{}},
 			},
 		},
-		// handle input with bracket notation when codec is json_lines
+		// Transform bracket notation in TCS input lines when codec is json_lines
 		{
 			input: `{"input": ["{\"[test][path]\": \"test\"}"], "codec": "json_lines"}`,
 			expected: TestCaseSet{
 				Codec:         "json_lines",
-				InputLines:    []string{"{\"test\":{\"path\":\"test\"}}"},
+				InputLines:    []string{`{"test":{"path":"test"}}`},
 				IgnoredFields: []string{"@version"},
 				InputFields:   logstash.FieldSet{},
 				Events:        []logstash.FieldSet{{}},
+			},
+		},
+		// Ignore bracket notation in TC input lines when codec is line
+		{
+			input: `{"testcases": [{"input": ["{\"[test][path]\": \"test\"}"]}]}`,
+			expected: TestCaseSet{
+				Codec:         "line",
+				InputLines:    []string{`{"[test][path]": "test"}`},
+				IgnoredFields: []string{"@version"},
+				InputFields:   logstash.FieldSet{},
+				Events:        []logstash.FieldSet{{}},
+				TestCases: []TestCase{
+					{
+						InputFields: make(logstash.FieldSet),
+						InputLines:  []string{`{"[test][path]": "test"}`},
+					},
+				},
+			},
+		},
+		// Transform bracket notation in TC input lines when codec is json_lines
+		{
+			input: `{"testcases": [{"input": ["{\"[test][path]\": \"test\"}"]}], "codec": "json_lines"}`,
+			expected: TestCaseSet{
+				Codec:         "json_lines",
+				InputLines:    []string{`{"test":{"path":"test"}}`},
+				IgnoredFields: []string{"@version"},
+				InputFields:   logstash.FieldSet{},
+				Events:        []logstash.FieldSet{{}},
+				TestCases: []TestCase{
+					{
+						InputFields: make(logstash.FieldSet),
+						InputLines:  []string{`{"test":{"path":"test"}}`},
+					},
+				},
 			},
 		},
 	}

--- a/internal/testcase/testcase_test.go
+++ b/internal/testcase/testcase_test.go
@@ -51,7 +51,7 @@ func TestNew(t *testing.T) {
 				IgnoredFields: []string{"@version", "foo"},
 			},
 		},
-		// Fields with bracket notation
+		// Fields with bracket notation.
 		{
 			input: `{"fields": {"type": "mytype", "[log][file][path]": "/tmp/file.log"}}`,
 			expected: TestCaseSet{
@@ -67,7 +67,7 @@ func TestNew(t *testing.T) {
 				IgnoredFields: []string{"@version"},
 			},
 		},
-		// Ignore bracket notation in TCS input lines when codec is line
+		// Ignore bracket notation in TCS input lines when codec is line.
 		{
 			input: `{"input": ["{\"[test][path]\": \"test\"}"]}`,
 			expected: TestCaseSet{
@@ -78,7 +78,7 @@ func TestNew(t *testing.T) {
 				Events:        []logstash.FieldSet{{}},
 			},
 		},
-		// Transform bracket notation in TCS input lines when codec is json_lines
+		// Transform bracket notation in TCS input lines when codec is json_lines.
 		{
 			input: `{"input": ["{\"[test][path]\": \"test\"}"], "codec": "json_lines"}`,
 			expected: TestCaseSet{
@@ -89,7 +89,7 @@ func TestNew(t *testing.T) {
 				Events:        []logstash.FieldSet{{}},
 			},
 		},
-		// Ignore bracket notation in TC input lines when codec is line
+		// Ignore bracket notation in TC input lines when codec is line.
 		{
 			input: `{"testcases": [{"input": ["{\"[test][path]\": \"test\"}"]}]}`,
 			expected: TestCaseSet{
@@ -106,7 +106,7 @@ func TestNew(t *testing.T) {
 				},
 			},
 		},
-		// Transform bracket notation in TC input lines when codec is json_lines
+		// Transform bracket notation in TC input lines when codec is json_lines.
 		{
 			input: `{"testcases": [{"input": ["{\"[test][path]\": \"test\"}"]}], "codec": "json_lines"}`,
 			expected: TestCaseSet{


### PR DESCRIPTION
Found this while working on #97. Contrary to the documentation, using bracket field references in the testcases array didn't actually work. The substitution only took place for the now-deprecated "input" key. In other words,

    codec: json_lines
    input:
      - '{"[foo][bar]": "value"}'

worked as expected, but

    codec: json_lines
    testcases:
      input: - '{"[foo][bar]": "value"}'

didn't. This has been addressed so that the "input" arrays work the same in both places.