### PR TITLE
Makefile: Stop building release tarballs with Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ EXEC_SUFFIX :=
 OS_NAME := $(shell uname -s)
 endif
 
-# The Docker image to use when building release images.
-GOLANG_DOCKER_IMAGE := golang:1.22.4
-
 INSTALL := install
 
 # Installation prefix directory. Could be changed to e.g. /usr or
@@ -122,16 +119,13 @@ dist/$(PROGRAM)_$(VERSION).tar.gz:
 
 dist/$(PROGRAM)_$(VERSION)_%.tar.gz: $(GOVVV)
 	mkdir -p $(dir $@)
-	GOOS="$$(basename $@ .tar.gz | awk -F_ '{print $$3}')" && \
-	    GOARCH="$$(basename $@ .tar.gz | awk -F_ '{print $$4}')" && \
+	export GOOS="$$(basename $@ .tar.gz | awk -F_ '{print $$3}')" && \
+	    export GOARCH="$$(basename $@ .tar.gz | awk -F_ '{print $$4}')" && \
 	    DISTDIR=dist/$${GOOS}_$${GOARCH} && \
 	    if [ $$GOOS = "windows" ] ; then EXEC_SUFFIX=".exe" ; fi && \
 	    mkdir -p $$DISTDIR && \
 	    cp CHANGELOG.md LICENSE README.md $$DISTDIR && \
-	    docker run --rm -v $$(pwd):$$(pwd) -w $$(pwd) \
-	        -e GOOS=$$GOOS -e GOARCH=$$GOARCH \
-	        $(GOLANG_DOCKER_IMAGE) \
-	        bin/govvv build -o $$DISTDIR/$(PROGRAM)$$EXEC_SUFFIX && \
+	    bin/govvv build -o $$DISTDIR/$(PROGRAM)$$EXEC_SUFFIX && \
 	    tar -C $$DISTDIR -zcpf $@ . && \
 	    rm -rf $$DISTDIR
 


### PR DESCRIPTION
With the toolchain support added in Go 1.21 there's hardly any need to build the release tarballs via a Docker container with the desired Go version. Apart from getting rid of an unnecessary dependency, the release-tarballs target started working a while back when Git started complaining about .git directories with the wrong owner, resulting in the following error message:

    failed to collect values: failed to get commit: git: error="exit status 128" stderr=fatal: detected dubious ownership in repository at '<DIR>/logstash-filter-verifier'